### PR TITLE
Improve service typing and modernize core landing layout

### DIFF
--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -1,180 +1,118 @@
 .main-container__home-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1.5rem 1rem 2rem;
   display: flex;
   flex-direction: column;
-  gap: 20px;
-  padding: 10px;
-
-  p {
-    color: #ff8c00;
-    font-size: 1.3rem;
-  }
+  gap: 1.8rem;
 
   .home-container__hero-block {
-    background: linear-gradient(135deg, #ff8c00 0%, #00bfff 100%);
+    background: radial-gradient(circle at top left, #1d4ed8, #312e81 52%, #111827);
     color: #fff;
     text-align: center;
-    padding: 60px 20px;
-    border-radius: 10px;
-    margin-bottom: 20px;
+    padding: 4rem 1.4rem;
+    border-radius: 1rem;
 
     .hero-block__hero-title {
-      font-size: 2rem;
-      margin-bottom: 20px;
+      font-size: clamp(1.8rem, 3vw, 2.8rem);
+      margin-bottom: 0.9rem;
     }
 
     .hero-block__hero-subtitle {
-      font-size: 1.1rem;
-      margin-bottom: 30px;
-      max-width: 600px;
-      margin: 0 auto 30px;
-      color: #ffffff;
-      font-size: 1.3rem;
-
+      font-size: 1.06rem;
+      max-width: 680px;
+      margin: 0 auto 1.6rem;
+      color: #dbeafe;
+      line-height: 1.5;
     }
 
     .hero-block__hero-cta {
       background: #fff;
-      color: #333;
-      border: none;
-      padding: 10px 20px;
-      font-size: 1rem;
-      border-radius: 25px;
+      color: #111827;
+      border: 0;
+      padding: 0.7rem 1.2rem;
+      border-radius: 0.7rem;
+      font-weight: 600;
       cursor: pointer;
-
-      &:hover {
-        background: #f0f0f0;
-      }
     }
   }
 
+  .home-container__section-subtitle,
+  .main-container__section-subtitle,
+  .why-us__section-title {
+    font-size: clamp(1.25rem, 2.2vw, 1.8rem);
+    font-weight: 700;
+    color: #111827;
+  }
+
   .home-container__why-us {
-    text-align: center;
-    margin-bottom: 20px;
-
-    .why-us__section-title {
-      font-size: 1.8rem;
-      color: #ff8c00;
-      margin-bottom: 20px;
-    }
-
     .why-us__features-list {
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: space-around;
-      gap: 20px;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 1rem;
 
       .features-list__feature-item {
         background: #fff;
-        border-radius: 10px;
-        flex: 1 1 200px;
-        max-width: 220px;
-        padding: 20px;
-        text-align: center;
-        box-shadow: 0 4px 10px rgba(0, 0, 0, 0.05);
+        border: 1px solid #e5e7eb;
+        border-radius: 0.9rem;
+        padding: 1rem;
+        transition: transform 0.2s ease;
+
+        &:hover {
+          transform: translateY(-2px);
+        }
 
         .feature-item__feature-icon {
-          font-size: 2rem;
-          margin-bottom: 10px;
+          font-size: 1.7rem;
           display: block;
+          margin-bottom: 0.5rem;
         }
 
         .feature-item__feature-title {
-          font-size: 1.2rem;
-          margin-bottom: 10px;
-          color: #333;
+          font-size: 1.05rem;
+          color: #0f172a;
+          margin-bottom: 0.35rem;
         }
 
         .feature-item__feature-desc {
-          font-size: 0.9rem;
-          color: #555;
+          color: #475569;
+          line-height: 1.4;
         }
       }
     }
   }
 
   .home-container__custom-hr {
-    border-top: 3px solid #ff8c00;
-    border-bottom: 3px solid #00bfff;
-    border-left: none;
-    border-right: none;
-    width: 60vw;
-    margin: 40px auto;
+    border: 0;
+    height: 1px;
+    background: linear-gradient(to right, transparent, #cbd5e1, transparent);
   }
 
   .home-container__community-info {
     text-align: center;
     background: #fff;
-    padding: 40px 20px;
-    border-radius: 10px;
-    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.05);
-    .community-info__section-title{
-      font-size: 2rem;
-      color: #242424;
+    border: 1px solid #e5e7eb;
+    border-radius: 1rem;
+    padding: 2rem 1rem;
+
+    .community-info__section-title {
+      color: #0f172a;
     }
+
     .community-info__community-desc {
-      font-size: 1rem;
-      color: #555;
-      max-width: 600px;
-      margin: 20px auto;
+      color: #475569;
+      max-width: 640px;
+      margin: 0.9rem auto 1.2rem;
     }
 
     .community-info__secondary-btn {
-      background: #ff8c00;
+      border: 0;
+      border-radius: 0.7rem;
+      padding: 0.7rem 1.2rem;
+      background: linear-gradient(135deg, #2563eb, #7c3aed);
       color: #fff;
-      border: none;
-      padding: 10px 20px;
-      font-size: 1rem;
-      border-radius: 25px;
+      font-weight: 600;
       cursor: pointer;
-
-      &:hover {
-        background: #e67e00;
-      }
-    }
-  }
-
-  .home-container__last-added-course {
-    margin: 20px auto;
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-
-    .home-container__card-wrapper {
-      flex: 1 0 21%;
-      margin: 10px;
-      max-width: 23%;
-    }
-  }
-
-  @media (max-width: 768px) {
-    p {
-      font-size: 1.2rem;
-    }
-
-    .ome-container__last-added-course {
-      justify-content: space-around;
-
-      .home-container__card-wrapper {
-        flex: 1 0 45%;
-        max-width: 45%;
-      }
-    }
-  }
-
-  @media (max-width: 480px) {
-    p {
-      font-size: 1.1rem;
-    }
-
-    .main-container__home-container__last-added-course {
-      flex-direction: column;
-      justify-content: center;
-
-      .main-container__home-container__card-wrapper {
-        flex: 1 0 100%;
-        max-width: 100%;
-        margin: 10px 0;
-      }
     }
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 "use client"; // Для клиентской отрисовки в Next.js
-import React, { useState, useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import SiteService from "@/services/siteNoAuth.service";
 import NewAddedCourse from "@/components/HomeComponents/NewAddedCourse";
 import LatestNews from "@/components/HomeComponents/LatestNews";
@@ -14,18 +14,12 @@ interface Course {
 
 export default function Home() {
   const [lastAddedCourses, setLastAddedCourses] = useState<Course[]>([]);
-  const [teacherId, setTeacherId] = useState<boolean>(false);
-  const items = "8";
+  const items = 8;
 
   useEffect(() => {
     document.title = "Courserio - Lms - цифровая платформа обучения";
   }, []);
 
-  useEffect(() => {
-    if (typeof window !== "undefined" && localStorage.getItem("access_token")) {
-      setTeacherId(true);
-    }
-  }, [teacherId]);
 
   useEffect(() => {
     const fetchData = async () => {

--- a/src/components/basicComponents/Footer/Footer.scss
+++ b/src/components/basicComponents/Footer/Footer.scss
@@ -1,56 +1,73 @@
+footer {
+  margin-top: 2rem;
+  border-top: 1px solid #e5e7eb;
+  background: #0f172a;
+  color: #cbd5e1;
+}
+
 .footer__container {
-  display: flex;
-  justify-content: space-between;
-  flex-direction: row;
-  align-items: center;
-  padding: 20px;
-  background-color: #f8f8f8;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 1.2rem;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1.2rem;
+
+  p {
+    margin: 0;
+  }
 
   .container__logo {
-    font-size: 1.2rem;
+    color: #e2e8f0;
+    line-height: 1.4;
   }
 
-  .container__links {
-    // Ваши стили для блока ссылок
-    display: flex;
-    flex-direction: column;
-  }
-
+  .container__links,
+  .container__contacts,
   .container__social-links {
     display: flex;
-    gap: 10px;
+    flex-direction: column;
+    gap: 0.5rem;
 
-    .social-icon {
-      font-size: 1.5rem;
-      color: #000;
-      transition: color 0.3s;
-
-      &:hover {
-        color: #007bff;
-      }
+    > p:first-child {
+      font-weight: 700;
+      color: #f8fafc;
     }
   }
-}
 
-// Медиа-запрос для мобильных устройств
-@media (max-width: 768px) {
-  .footer__container {
-    flex-direction: column;
-    align-items: center;
-    text-align: center;
-    gap: 20px;
+  a {
+    color: #cbd5e1;
+    text-decoration: none;
+
+    &:hover {
+      color: #93c5fd;
+    }
   }
 
   .container__social-links {
-    justify-content: center;
+    flex-direction: row;
+    align-items: center;
+
+    .social-icon {
+      font-size: 1.2rem;
+    }
+  }
+
+  .footer__credit {
+    grid-column: 1 / -1;
+    padding-top: 1rem;
+    border-top: 1px solid rgba(203, 213, 225, 0.2);
   }
 }
-a {
-  color: rgb(99, 99, 99); /* Измените цвет на серый */
-  text-decoration: none; /* Убираем подчеркивание */
-  transition: color 0.3s; /* Добавим плавный переход для изменения цвета при наведении */
 
-  &:hover {
-    color: rgb(53, 53, 53); /* Цвет ссылки при наведении (можно изменить по желанию) */
+@media (max-width: 900px) {
+  .footer__container {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .footer__container {
+    grid-template-columns: 1fr;
   }
 }

--- a/src/components/basicComponents/Footer/Footer.tsx
+++ b/src/components/basicComponents/Footer/Footer.tsx
@@ -1,37 +1,46 @@
-"use client"; // This directive must be at the top
+"use client";
 import React from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faVk, faTelegramPlane } from "@fortawesome/free-brands-svg-icons";
 import "./Footer.scss";
-import Link from 'next/link'
+import Link from "next/link";
 
 function Footer() {
   return (
     <footer>
       <div className="footer__container">
-        <div className="container__logo">
-          2024. courserio, LMS - современная система обучения.
-        </div>
+        <div className="container__logo">2024. Courserio — LMS платформа для современного онлайн-обучения.</div>
+
         <div className="container__links">
           <p>Ссылки</p>
-          <Link href="/license" className="nav-link">Пользовательское соглашение</Link>
-          {/* Добавляем ссылку на Flowbyte */}
+          <Link href="/license" className="nav-link">
+            Пользовательское соглашение
+          </Link>
         </div>
+
         <div className="container__contacts">
           <p>Контакты</p>
-          <p>Email: <a href="mailto:manage@courserio.ru">manage@courserio.ru</a></p>
+          <p>
+            Email: <a href="mailto:manage@courserio.ru">manage@courserio.ru</a>
+          </p>
         </div>
+
         <div className="container__social-links">
-          <p>Мы в социальных сетях</p>
-          <a href="https://vk.com/courserio" target="_blank" rel="noopener noreferrer">
+          <p>Мы в соцсетях:</p>
+          <a href="https://vk.com/courserio" target="_blank" rel="noopener noreferrer" aria-label="Courserio VK">
             <FontAwesomeIcon icon={faVk} className="social-icon" />
           </a>
-          <a href="https://t.me/courserio" target="_blank" rel="noopener noreferrer">
+          <a href="https://t.me/courserio" target="_blank" rel="noopener noreferrer" aria-label="Courserio Telegram">
             <FontAwesomeIcon icon={faTelegramPlane} className="social-icon" />
           </a>
         </div>
-        <p>Разработано веб студией <Link href="https://flowbyte.ru" className="nav-link" target="_blank" rel="noopener noreferrer">Flowbyte</Link></p>
 
+        <p className="footer__credit">
+          Разработано веб-студией{" "}
+          <Link href="https://flowbyte.ru" className="nav-link" target="_blank" rel="noopener noreferrer">
+            Flowbyte
+          </Link>
+        </p>
       </div>
     </footer>
   );

--- a/src/components/basicComponents/Header/Header.scss
+++ b/src/components/basicComponents/Header/Header.scss
@@ -1,249 +1,167 @@
 .container__header-container {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.9rem 1.5rem;
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid #e5e7eb;
+
+  .header-container__logo-and-menu {
     display: flex;
-    flex-direction: row;
-    justify-content: space-between;
     align-items: center;
-    padding: 10px;
-    background-color: #ffffff;
-    border-bottom: 0.1rem solid #ff634756;
-    .header-container__logo-and-menu {
-        display: flex;
-        flex-direction: row;
-        .logo-an-menu__logo {
-            font-size: 2rem;
-            font-weight: 800;
-            color: #00c3ff;
-            text-decoration: none;
+    gap: 1rem;
 
-            &:hover,
-            &:active,
-            &:focus {
-                color: #00c3ff;
-                cursor: pointer;
-            }
-        }
-
-        .menu-toggle {
-            display: none;
-            background: none;
-            border: none;
-            font-size: 2rem;
-            cursor: pointer;
-        }
+    .logo-an-menu__logo {
+      font-size: 1.6rem;
+      font-weight: 800;
+      color: #111827;
+      text-decoration: none;
+      letter-spacing: 0.02em;
     }
 
-    .header-container__navbar {
-        display: flex;
-        flex-direction: row;
-
-        .navbar__buttons {
-            display: flex;
-            gap: 10px;
-        }
-
-        .nav-link {
-            display: inline-block;
-            padding: 10px 20px;
-            font-size: 1.8rem;
-            color: #00c3ff;
-            text-decoration: none;
-            border-radius: 4px;
-            position: relative;
-            transition: all 0.3s ease;
-            z-index: 1;
-
-            &::before {
-                content: "";
-                position: absolute;
-                bottom: 0;
-                left: 0;
-                width: 100%;
-                height: 0;
-                background-color: #ccf5fc;
-                z-index: -1;
-                transition: all 0.3s ease;
-                border-radius: 4px;
-                opacity: 0;
-                transform: translateY(100%);
-            }
-
-            &:hover::before {
-                height: 100%;
-                opacity: 1;
-                transform: translateY(0);
-                box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-            }
-        }
-
-        .nav-dropdown-toggle {
-            cursor: pointer;
-            padding: 10px 20px;
-            background-color: #007bff;
-            color: #fff;
-            border-radius: 4px;
-            transition: all 0.3s ease;
-
-            &:hover {
-                background-color: #0056b3;
-                box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-                transform: translateY(-2px);
-            }
-        }
-
-        .nav-dropdown {
-            position: relative;
-
-            .nav-dropdown-toggle {
-                padding: 10px 20px;
-                font-size: 1.8rem;
-                cursor: pointer;
-            }
-
-            .nav-dropdown-menu {
-                display: none;
-                position: absolute;
-                top: 100%;
-                left: 0;
-                z-index: 100;
-                background-color: #fff;
-                border: 1px solid #ccc;
-                padding: 10px;
-                box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
-            }
-
-            &:hover .nav-dropdown-menu {
-                display: block;
-            }
-
-            .nav-dropdown-item {
-                display: block;
-                color: #333;
-                text-decoration: none;
-                padding: 5px 0;
-                transition: background-color 0.3s;
-
-                &:hover {
-                    background-color: #f0f0f0;
-                }
-            }
-        }
-
-        .nav-link__button,
-        .nav-link__register-btn,
-        .nav-link__login-btn {
-            padding: 10px 20px;
-            font-size: 1.8rem;
-            color: #ffffff;
-            background-color: transparent;
-            border: none;
-            cursor: pointer;
-            transition: all 0.3s ease;
-
-            &:hover {
-                color: #ffffff;
-                background-color: #ffffff;
-            }
-        }
-
-        .nav-link__register-btn {
-            background-color: #ff7f50;
-
-            &:hover {
-                background-color: #ff6347;
-            }
-        }
-
-        .nav-link__login-btn {
-            background-color: #00c3ff;
-            color: #ffffff;
-
-            &:hover {
-                background-color: #0056b3;
-            }
-        }
+    .menu-toggle {
+      display: none;
+      border: 1px solid #e5e7eb;
+      background: #fff;
+      border-radius: 0.5rem;
+      font-size: 1.25rem;
+      width: 2.2rem;
+      height: 2.2rem;
     }
+  }
+
+  .header-container__navbar .navbar__buttons {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+
+    .nav-link,
+    .nav-dropdown-toggle {
+      text-decoration: none;
+      font-size: 1rem;
+      color: #374151;
+      border-radius: 0.6rem;
+      padding: 0.55rem 0.9rem;
+      transition: background 0.2s ease, color 0.2s ease;
+
+      &:hover {
+        background: #f3f4f6;
+        color: #111827;
+      }
+    }
+
+    .nav-dropdown {
+      position: relative;
+
+      .nav-dropdown-toggle {
+        cursor: pointer;
+      }
+
+      .nav-dropdown-menu {
+        position: absolute;
+        top: calc(100% + 0.4rem);
+        right: 0;
+        min-width: 210px;
+        display: none;
+        flex-direction: column;
+        gap: 0.3rem;
+        padding: 0.6rem;
+        border-radius: 0.75rem;
+        background: #ffffff;
+        border: 1px solid #e5e7eb;
+        box-shadow: 0 10px 20px rgba(0, 0, 0, 0.08);
+      }
+
+      &:hover .nav-dropdown-menu {
+        display: flex;
+      }
+
+      .nav-dropdown-item {
+        text-decoration: none;
+        color: #374151;
+        padding: 0.45rem 0.6rem;
+        border-radius: 0.5rem;
+
+        &:hover {
+          background: #f3f4f6;
+        }
+      }
+    }
+
+    .nav-link__register-btn,
+    .nav-link__login-btn {
+      border: none;
+      border-radius: 0.6rem;
+      padding: 0.55rem 0.95rem;
+      font-size: 0.95rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: transform 0.2s ease, opacity 0.2s ease;
+
+      &:hover {
+        transform: translateY(-1px);
+        opacity: 0.9;
+      }
+    }
+
+    .nav-link__login-btn {
+      background: #111827;
+      color: #fff;
+    }
+
+    .nav-link__register-btn {
+      background: linear-gradient(135deg, #2563eb, #7c3aed);
+      color: #fff;
+    }
+  }
 }
 
 @media (max-width: 768px) {
-    .container__header-container {
+  .container__header-container {
+    flex-direction: column;
+    align-items: stretch;
+
+    .header-container__logo-and-menu {
+      justify-content: space-between;
+      .menu-toggle {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+      }
+    }
+
+    .header-container__navbar {
+      display: none;
+
+      &.open {
+        display: block;
+      }
+
+      .navbar__buttons {
         flex-direction: column;
-        align-items: flex-start;
-    
-        .header-container__logo-and-menu {
-            align-items: flex-start;
-            width: 100%;
-            .menu-toggle {
-                display: block;
-                margin-left: auto; /* Сдвигает элемент вправо */
-            }
+        align-items: stretch;
+        padding-top: 0.7rem;
+
+        .nav-link,
+        .nav-dropdown-toggle,
+        .nav-link__login-btn,
+        .nav-link__register-btn {
+          width: 100%;
+          text-align: left;
         }
-    
-        .header-container__navbar {
-            display: none;
-            flex-direction: column;
-            width: 100%;
 
-            &.open {
-                display: flex;
-            }
-
-            .navbar__buttons {
-                flex-direction: column;
-                width: 100%;
-            }
-
-            .nav-link {
-                width: 100%;
-                text-align: center;
-                padding: 15px 0;
-            }
-
-            .nav-link__login-btn,
-            .nav-link__register-btn {
-                width: 100%;
-                text-align: center;
-                padding: 15px 0;
-            }
-
-            .nav-dropdown-menu {
-                position: static;
-                width: 100%;
-                box-shadow: none;
-                border: none;
-                background-color: transparent;
-
-                .nav-dropdown-item {
-                    padding: 10px 20px;
-                }
-            }
-
-            .nav-dropdown-toggle {
-                width: 100%;
-                text-align: center;
-            }
+        .nav-dropdown .nav-dropdown-menu {
+          position: static;
+          display: flex;
+          margin-top: 0.2rem;
+          box-shadow: none;
+          border: 1px solid #f3f4f6;
         }
+      }
     }
-}
-
-@media (max-width: 480px) {
-    .container__header-container {
-        .header-container__logo {
-            font-size: 1.5rem;
-        }
-
-        .header-container__navbar {
-            .nav-link {
-                font-size: 1.5rem;
-            }
-
-            .nav-link__login-btn,
-            .nav-link__register-btn {
-                font-size: 1.5rem;
-            }
-
-            .nav-dropdown-toggle {
-                font-size: 1.5rem;
-            }
-        }
-    }
+  }
 }

--- a/src/components/basicComponents/Header/Header.tsx
+++ b/src/components/basicComponents/Header/Header.tsx
@@ -1,126 +1,133 @@
-"use client"; // This directive must be at the top
-import React, { useState, useEffect } from "react";
-import Link from 'next/link';
-import "./Header.scss"; // Import SCSS file
+"use client";
+import React, { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import "./Header.scss";
 import TabsAuth from "../Auth/TabsLoginRegister/TabComponent/Tabs";
 import LmsModalBase from "../../reUseComponents/ModalBase";
-import LmsDrawerBase from "../../reUseComponents/Drawer"; // Новый компонент Drawer
-import { MenuOutlined } from '@ant-design/icons';
+import LmsDrawerBase from "../../reUseComponents/Drawer";
+import { MenuOutlined } from "@ant-design/icons";
 import { useRouter } from "next/navigation";
 
+type AuthMode = "login" | "register";
+type UserRole = "teacher_model" | "student_model" | null;
+
 function Header() {
-  const [authState, setAuthState] = useState("");
+  const [authState, setAuthState] = useState<AuthMode>("login");
   const [openModal, setOpenModal] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
+  const [role, setRole] = useState<UserRole>(null);
+  const [isAuth, setIsAuth] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const router = useRouter();
 
-  const handleShow = (auth) => {
-    handleOpenModal();
+  const handleShow = (auth: AuthMode) => {
+    setOpenModal(true);
     setAuthState(auth);
   };
 
-  const handleOpenModal = () => setOpenModal(true);
   const handleCloseModal = () => setOpenModal(false);
-  const contentToModal = (<TabsAuth authState={authState} handleCloseModal={handleCloseModal} />);
 
   useEffect(() => {
-    const handleResize = () => {
-      setIsMobile(window.innerWidth <= 768);
-    };
-    
-    handleResize(); // Проверка при первой загрузке
-    
-    window.addEventListener('resize', handleResize); // Отслеживание изменения размера
-    
-    return () => {
-      window.removeEventListener('resize', handleResize);
-    };
-  }, []);
-
-  const [role, setRole] = useState<string | null>(null);
-  const [isAuth, setIsAuth] = useState(false);
-  const [menuOpen, setMenuOpen] = useState(false);
-
-  useEffect(() => {
-    const token = localStorage.getItem('access_token');
-    if (token) {
-      setIsAuth(true);
+    if (typeof window === "undefined") {
+      return;
     }
-  }, [isAuth]);
 
-  useEffect(() => {
-    const storedRole = localStorage.getItem('role');
+    const handleResize = () => setIsMobile(window.innerWidth <= 768);
+
+    const token = localStorage.getItem("access_token");
+    const storedRole = localStorage.getItem("role");
+
+    setIsAuth(Boolean(token));
     if (storedRole) {
-      setRole(JSON.parse(storedRole));
+      setRole(JSON.parse(storedRole) as UserRole);
     }
+
+    handleResize();
+    window.addEventListener("resize", handleResize);
+
+    return () => window.removeEventListener("resize", handleResize);
   }, []);
 
-  const toggleMenu = () => setMenuOpen(!menuOpen);
-
-  const router = useRouter();
+  const toggleMenu = () => setMenuOpen((prev) => !prev);
 
   const handleLogout = () => {
-    localStorage.clear(); // Clear all local storage items
+    localStorage.clear();
     setIsAuth(false);
-    router.push('/'); // Redirect to home page
+    setRole(null);
+    router.push("/");
   };
 
+  const contentToModal = useMemo(
+    () => <TabsAuth authState={authState} handleCloseModal={handleCloseModal} />,
+    [authState],
+  );
+
   return (
-    <div className="container__header-container">
+    <header className="container__header-container">
       <div className="header-container__logo-and-menu">
         <Link href="/" className="logo-an-menu__logo">
           Courserio
         </Link>
-        <button className="menu-toggle" onClick={toggleMenu}>
+        <button className="menu-toggle" onClick={toggleMenu} aria-label="Открыть меню">
           <MenuOutlined />
         </button>
       </div>
 
-      <div className={`header-container__navbar ${menuOpen ? 'open' : ''}`}>
+      <nav className={`header-container__navbar ${menuOpen ? "open" : ""}`}>
         <div className="navbar__buttons">
-          <Link href="/category" className="nav-link">Курсы</Link>
-          <Link href="/news-blog" className="nav-link">Новости</Link>   
-          <Link href="/about" className="nav-link">О нас</Link>
+          <Link href="/category" className="nav-link">
+            Курсы
+          </Link>
+          <Link href="/news-blog" className="nav-link">
+            Новости
+          </Link>
+          <Link href="/about" className="nav-link">
+            О нас
+          </Link>
           {isAuth ? (
             <div className="nav-dropdown">
               <div className="nav-dropdown-toggle">Профиль</div>
               <div className="nav-dropdown-menu">
                 {role === "teacher_model" && (
-                  <Link href="/teacher-profile/dashboard" className="nav-dropdown-item">Личный кабинет учителя</Link>
+                  <Link href="/teacher-profile/dashboard" className="nav-dropdown-item">
+                    Личный кабинет учителя
+                  </Link>
                 )}
                 {role === "student_model" && (
-                  <Link href="/student-profile/dashboard" className="nav-dropdown-item">Личный кабинет ученика</Link>
+                  <Link href="/student-profile/dashboard" className="nav-dropdown-item">
+                    Личный кабинет ученика
+                  </Link>
                 )}
-                <Link href="/" className="nav-dropdown-item" onClick={(e) => {
-  e.preventDefault(); // Prevent the default link behavior
-  handleLogout(); // Call the logout function
-}}>
-  Выход
-</Link>
+                <Link
+                  href="/"
+                  className="nav-dropdown-item"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    handleLogout();
+                  }}
+                >
+                  Выход
+                </Link>
               </div>
             </div>
           ) : (
             <>
               {isMobile ? (
-                <LmsDrawerBase
-                  open={openModal}
-                  onClose={handleCloseModal}
-                  content={contentToModal}
-                />
+                <LmsDrawerBase open={openModal} onClose={handleCloseModal} content={contentToModal} />
               ) : (
-                <LmsModalBase
-                  open={openModal}
-                  onClose={handleCloseModal}
-                  content={contentToModal}
-                  showCloseIcon={true}
-                />
+                <LmsModalBase open={openModal} onClose={handleCloseModal} content={contentToModal} showCloseIcon />
               )}
-              <button className="nav-link__login-btn" onClick={() => handleShow("login")}>Войти</button>
-              <button className="nav-link__register-btn" onClick={() => handleShow("register")}>Зарегистрироваться</button>
+              <button className="nav-link__login-btn" onClick={() => handleShow("login")}>
+                Войти
+              </button>
+              <button className="nav-link__register-btn" onClick={() => handleShow("register")}>
+                Регистрация
+              </button>
             </>
           )}
         </div>
-      </div>
-    </div>
+      </nav>
+    </header>
   );
 }
 

--- a/src/services/course.editor.service.ts
+++ b/src/services/course.editor.service.ts
@@ -1,122 +1,111 @@
-import { apiLmsUrl} from "../shared/config";
+import { apiLmsUrl } from "../shared/config";
 import api from "./api";
 
-const editCoursePageGetModuleStage = async (module_id) => {
-    // console.log(course_id)
-    return await api
-        .get(apiLmsUrl + "module-stage-list/" + module_id)
-}
+type Id = number | string | string[];
+type SortableItem = { id: Id; sort_index: number };
+type Payload = unknown;
 
-// const editCoursePageDeleteModuleStage = async (course_id, module_id, data) => {
-//     return await api
-//         .delete(apiLmsUrl + "module-stage-detail/" + module_id + "/" + data)
-// }
-// const editCoursePageGetCourse = async (course_id) => {
-//     return await api
-//         .get(apiLmsUrl + "course-detail/" + course_id)
-// }
-const editCoursePageGetChapterList = async (course_id: number) => {
-    return await api
-        .get(apiLmsUrl + "course-chapter-list/" + course_id)
-}
-const editCoursePageAddChapter = async (data) => {
-    return await api
-        .post(apiLmsUrl + "add_chapter_to_course/", data)
-}
-const editCoursePageUpdateChapter = async (chapterId, data) => {
-    return await api
-        .put(apiLmsUrl + `update-chapter/${chapterId}`, data)
-}
-const editCourseUpdateChapterSortIndexes = async (course_id, chapters) => {
-    return await api
-        .put(`${apiLmsUrl}update_chapters_sort_indexes/${course_id}`, chapters);
-}
-const editCoursePageDeleteChapter = async (chapter_id) => {
-    return await api
-        .delete(`${apiLmsUrl}delete-chapter/?chapter_id=${chapter_id}`)
-}
-const editCoursePageAddModule = async (data) => {
-    return await api
-        .post(apiLmsUrl + "add_module_to_chapter/", data)
-}
-const editCoursePageUpdateModule = async (moduleId, data) => {
-    return await api
-        .put(apiLmsUrl + `update-module/${moduleId}`, data)
-}
-const editCourseUpdateModuleSortIndexes = async (chapter_id, modules) => {
-    return await api
-        .put(`${apiLmsUrl}update_modules_sort_indexes/${chapter_id}`, modules);
-}
-const editCoursePagePatchModule = async (moduleId, data) => {
-    return await api
-        .patch(apiLmsUrl + `patch-module/${moduleId}`, data)
-}
-const editCoursePageDeleteModule = async (module_id) => {
-    return await api
-        .delete(`${apiLmsUrl}delete-module/?module_id=${module_id}`)
-}
-const editCoursePageDeleteStage = async (stage_id) => {
-    return await api
-        .delete(`${apiLmsUrl}delete-stage/${stage_id}`)
-}
-const editCourseUpdateStageSortIndexes = async (moduleId, stages) => {
-    return await api.put(`${apiLmsUrl}update_stages_sort_indexes/${moduleId}`, stages);
-}
-const editCoursePageGetLesson = async (stagePk) => {
-    return await api
-        .get(`${apiLmsUrl}stage/${stagePk}`)
-}
-const editCoursePageAddClassicLesson = async (data) => {
-    return await api
-        .post(`${apiLmsUrl}add_stage_to_module/classic_lesson/`, data)
-}
-const editCoursePageUpdateClassicLesson = async (data) => {
-    return await api
-        .put(apiLmsUrl + "update/classic_lesson/", data)
-}
-const editCoursePageAddVideoLesson = async (data) => {
-    return await api
-        .post(`${apiLmsUrl}add_stage_to_module/video_lesson/`, data)
-}
-const editCoursePageUpdateVideoLesson = async (data) => {
-    return await api
-    .put(apiLmsUrl + "update/video_lesson/", data)
-}
-const editCoursePageAddQuizLesson = async (data) => {
-    return await api
-        .post(`${apiLmsUrl}add_stage_to_module/quiz_lesson/`, data)
-}
-const editCoursePageUpdateQuizLesson = async (data) => {
-    return await api
-    .put(apiLmsUrl + "update/quiz_lesson/", data)
-}
+const editCoursePageGetModuleStage = async (moduleId: Id) => {
+  return await api.get(`${apiLmsUrl}module-stage-list/${moduleId}`);
+};
 
+const editCoursePageGetChapterList = async (courseId: Id) => {
+  return await api.get(`${apiLmsUrl}course-chapter-list/${courseId}`);
+};
+
+const editCoursePageAddChapter = async (data: Payload) => {
+  return await api.post(`${apiLmsUrl}add_chapter_to_course/`, data);
+};
+
+const editCoursePageUpdateChapter = async (chapterId: Id, data: Payload) => {
+  return await api.put(`${apiLmsUrl}update-chapter/${chapterId}`, data);
+};
+
+const editCourseUpdateChapterSortIndexes = async (courseId: Id, chapters: SortableItem[]) => {
+  return await api.put(`${apiLmsUrl}update_chapters_sort_indexes/${courseId}`, chapters);
+};
+
+const editCoursePageDeleteChapter = async (chapterId: Id) => {
+  return await api.delete(`${apiLmsUrl}delete-chapter/?chapter_id=${chapterId}`);
+};
+
+const editCoursePageAddModule = async (data: Payload) => {
+  return await api.post(`${apiLmsUrl}add_module_to_chapter/`, data);
+};
+
+const editCoursePageUpdateModule = async (moduleId: Id, data: Payload) => {
+  return await api.put(`${apiLmsUrl}update-module/${moduleId}`, data);
+};
+
+const editCourseUpdateModuleSortIndexes = async (chapterId: Id, modules: SortableItem[]) => {
+  return await api.put(`${apiLmsUrl}update_modules_sort_indexes/${chapterId}`, modules);
+};
+
+const editCoursePagePatchModule = async (moduleId: Id, data: Payload) => {
+  return await api.patch(`${apiLmsUrl}patch-module/${moduleId}`, data);
+};
+
+const editCoursePageDeleteModule = async (moduleId: Id) => {
+  return await api.delete(`${apiLmsUrl}delete-module/?module_id=${moduleId}`);
+};
+
+const editCoursePageDeleteStage = async (stageId: Id) => {
+  return await api.delete(`${apiLmsUrl}delete-stage/${stageId}`);
+};
+
+const editCourseUpdateStageSortIndexes = async (moduleId: Id, stages: SortableItem[]) => {
+  return await api.put(`${apiLmsUrl}update_stages_sort_indexes/${moduleId}`, stages);
+};
+
+const editCoursePageGetLesson = async (stagePk: Id) => {
+  return await api.get(`${apiLmsUrl}stage/${stagePk}`);
+};
+
+const editCoursePageAddClassicLesson = async (data: Payload) => {
+  return await api.post(`${apiLmsUrl}add_stage_to_module/classic_lesson/`, data);
+};
+
+const editCoursePageUpdateClassicLesson = async (data: Payload) => {
+  return await api.put(`${apiLmsUrl}update/classic_lesson/`, data);
+};
+
+const editCoursePageAddVideoLesson = async (data: Payload) => {
+  return await api.post(`${apiLmsUrl}add_stage_to_module/video_lesson/`, data);
+};
+
+const editCoursePageUpdateVideoLesson = async (data: Payload) => {
+  return await api.put(`${apiLmsUrl}update/video_lesson/`, data);
+};
+
+const editCoursePageAddQuizLesson = async (data: Payload) => {
+  return await api.post(`${apiLmsUrl}add_stage_to_module/quiz_lesson/`, data);
+};
+
+const editCoursePageUpdateQuizLesson = async (data: Payload) => {
+  return await api.put(`${apiLmsUrl}update/quiz_lesson/`, data);
+};
 
 const CourseEditorService = {
-    editCoursePageGetModuleStage,
-    // editCoursePageAddModuleStage,
-    editCoursePageGetLesson,
-    editCoursePagePatchModule,
-
-    // editCoursePageDeleteModuleStage,
-    // editCoursePageGetCourse,
-    editCoursePageGetChapterList,
-    editCoursePageAddChapter,
-    editCoursePageUpdateChapter,
-    editCourseUpdateChapterSortIndexes,
-    editCoursePageDeleteChapter,
-    editCoursePageAddModule,
-    editCoursePageUpdateModule,
-    editCourseUpdateModuleSortIndexes,
-    editCourseUpdateStageSortIndexes,
-    editCoursePageDeleteModule,
-    editCoursePageAddClassicLesson,
-    editCoursePageUpdateClassicLesson,
-    editCoursePageDeleteStage,
-    editCoursePageAddVideoLesson,
-    editCoursePageUpdateVideoLesson,
-    editCoursePageAddQuizLesson,
-    editCoursePageUpdateQuizLesson
+  editCoursePageGetModuleStage,
+  editCoursePageGetLesson,
+  editCoursePagePatchModule,
+  editCoursePageGetChapterList,
+  editCoursePageAddChapter,
+  editCoursePageUpdateChapter,
+  editCourseUpdateChapterSortIndexes,
+  editCoursePageDeleteChapter,
+  editCoursePageAddModule,
+  editCoursePageUpdateModule,
+  editCourseUpdateModuleSortIndexes,
+  editCourseUpdateStageSortIndexes,
+  editCoursePageDeleteModule,
+  editCoursePageAddClassicLesson,
+  editCoursePageUpdateClassicLesson,
+  editCoursePageDeleteStage,
+  editCoursePageAddVideoLesson,
+  editCoursePageUpdateVideoLesson,
+  editCoursePageAddQuizLesson,
+  editCoursePageUpdateQuizLesson,
 };
 
 export default CourseEditorService;

--- a/src/services/siteNoAuth.service.ts
+++ b/src/services/siteNoAuth.service.ts
@@ -1,63 +1,70 @@
 import axios from "axios";
-import { apiLmsUrl, apiUserUrl,  apiBaseUrl, apiBlogUrl } from "../shared/config";
+import { apiLmsUrl, apiUserUrl, apiBaseUrl, apiBlogUrl } from "../shared/config";
 import api from "./api";
 
-const getCategory = async ({ toSelect }) => {
-    return await api.get(apiBaseUrl + "category/", {
-        params: {
-            to_select: toSelect
-        }
-    });
-}
-const getCourse = async (course_id) => {
-    return await api.get(apiBaseUrl + `course/?course_id=${course_id}`, );
-}
-const getCourses = async (params) => {
-    console.log(params)
-    return await api.get(apiBaseUrl + `courses-by-cat/`,{params} );
-}
+type Id = number | string | string[];
 
-const homePageLastAddedCourses = async ({ items }) => {
-    return await api
-    .get(apiBaseUrl + `recent_courses/?items=${items}`)
-}
+type CoursesParams = Record<string, string | number | boolean | undefined>;
+
+const getCategory = async ({ toSelect }: { toSelect?: boolean }) => {
+  return await api.get(`${apiBaseUrl}category/`, {
+    params: {
+      to_select: toSelect,
+    },
+  });
+};
+
+const getCourse = async (courseId: Id) => {
+  return await api.get(`${apiBaseUrl}course/?course_id=${courseId}`);
+};
+
+const getCourses = async (params?: CoursesParams) => {
+  return await api.get(`${apiBaseUrl}courses-by-cat/`, { params });
+};
+
+const homePageLastAddedCourses = async ({ items }: { items: number | string }) => {
+  return await api.get(`${apiBaseUrl}recent_courses/?items=${items}`);
+};
+
 const homePagePopularCourses = async () => {
-    return await api
-    .get(apiLmsUrl + "popular-courses/?popular=1")
-}
+  return await api.get(`${apiLmsUrl}popular-courses/?popular=1`);
+};
+
 const homePagePopularTeachers = async () => {
-    return await api
-    .get(apiUserUrl + "popular-teachers/?popular=1")
-}
+  return await api.get(`${apiUserUrl}popular-teachers/?popular=1`);
+};
+
 const homePageStudentsreviews = async () => {
-    return await api
-    .get(apiLmsUrl + "student-testimonial/")
-}
-const allCoursesPage = async (url) => {
-    return await api
-    .get(url)
-}
-const getNewsBlog = async (items) => {
-    if (items) {
-      return await api.get(`${apiBlogUrl}news/?limit=${items}`);
-    }
-    return await api.get(`${apiBlogUrl}news/`);
-  };
-  
-const getBlogById = (id) => {
-    return axios.get(`${apiBlogUrl}news/${id}`);
-  };
+  return await api.get(`${apiLmsUrl}student-testimonial/`);
+};
+
+const allCoursesPage = async (url: string) => {
+  return await api.get(url);
+};
+
+const getNewsBlog = async (items?: number | string) => {
+  if (items) {
+    return await api.get(`${apiBlogUrl}news/?limit=${items}`);
+  }
+
+  return await api.get(`${apiBlogUrl}news/`);
+};
+
+const getBlogById = (id: Id) => {
+  return axios.get(`${apiBlogUrl}news/${id}`);
+};
+
 const SiteService = {
-    getCategory,
-    getCourse,
-    getCourses,
-    homePageLastAddedCourses,
-    homePagePopularCourses,
-    homePagePopularTeachers,
-    homePageStudentsreviews,
-    allCoursesPage,
-    getNewsBlog,
-    getBlogById,
+  getCategory,
+  getCourse,
+  getCourses,
+  homePageLastAddedCourses,
+  homePagePopularCourses,
+  homePagePopularTeachers,
+  homePageStudentsreviews,
+  allCoursesPage,
+  getNewsBlog,
+  getBlogById,
 };
 
 export default SiteService;

--- a/src/services/student.service.ts
+++ b/src/services/student.service.ts
@@ -1,107 +1,80 @@
-import { apiStudyUrl, apiUserUrl,  } from "../shared/config";
+import { apiStudyUrl, apiUserUrl } from "../shared/config";
 import api from "./api";
-// import authHeader from "./auth-header";
+
+type Id = number | string | string[];
+type Payload = unknown;
 
 const studentCourses = async () => {
-    return await api
-        .get(apiStudyUrl + "student/courses/"
-        )
-}
-const checkEnrollment = async (course_id) => {
-    return await api
-        .get(apiStudyUrl + "check-enrollment/?course_id="+course_id
-        )
-}
-const learnCoursePageGetChapterList = async (course_id) => {
-    return await api
-        .get(apiStudyUrl + "learning-course-chapter-list/" + course_id)
-}
-const getLearnLesson = async (stagePk) => {
-    return await api
-        .get(`${apiStudyUrl}stage/${stagePk}`)
-}
-const enrollToCourse = async (course_id) => {
-    return await api
-        .post(`${apiStudyUrl}enroll/${course_id}`,
+  return await api.get(`${apiStudyUrl}student/courses/`);
+};
 
-            // {headers: { "Content-Type": "multipart/form-data" }}
-        )
-}
-const unenrollStudent = async (course_id) => {
-    return await api.delete(`${apiStudyUrl}unenroll/${course_id}`);
-}
+const checkEnrollment = async (courseId: Id) => {
+  return await api.get(`${apiStudyUrl}check-enrollment/?course_id=${courseId}`);
+};
 
-const unenrollStudentLight = async (course_id) => {
-    return await api.patch(`${apiStudyUrl}unenroll/light/${course_id}`);
-}
-const learnGetModuleStages = async (module_id) => {
-    // console.log(course_id)
-    return await api
-        .get(apiStudyUrl + "module-stage-list/" + module_id)
-}
-const updateStage = async (stageId, isCompleted) => {
-    return await api
-        .post(`${apiStudyUrl}update_stage_progress/${stageId}/?is_completed=${isCompleted}`,
+const learnCoursePageGetChapterList = async (courseId: Id) => {
+  return await api.get(`${apiStudyUrl}learning-course-chapter-list/${courseId}`);
+};
 
-            // {headers: { "Content-Type": "multipart/form-data" }}
-        )
-}
+const getLearnLesson = async (stagePk: Id) => {
+  return await api.get(`${apiStudyUrl}stage/${stagePk}`);
+};
 
-const checkQuizLesson = async (stageId, answers) => {
-    return await api
-        .post(`${apiStudyUrl}check_quiz_answers/${stageId}`, answers
+const enrollToCourse = async (courseId: Id) => {
+  return await api.post(`${apiStudyUrl}enroll/${courseId}`);
+};
 
-            // {headers: { "Content-Type": "multipart/form-data" }}
-        )
-}
-// const deleteTeacherCourse = async (courseId) => {
-//     return await api
-//         .delete(apiLmsUrl + "teacher-courses-detail/" + courseId
-//         )
-// }
+const unenrollStudent = async (courseId: Id) => {
+  return await api.delete(`${apiStudyUrl}unenroll/${courseId}`);
+};
 
-// const teacherStudents = async (teacherId) => {
-//     return await api
-//         .get(apiLmsUrl + "teacher-students/" + teacherId
-//         )
-// }
-const startExam = async (chapter_id) => {
-    return await api
-        .post(`${apiStudyUrl}start_exam/${chapter_id}`)
-}
-const completeExam = async (chapter_id) => {
-    return await api
-        .post(`${apiStudyUrl}complete_exam/${chapter_id}`)
-}
-const chapterStart = async (chapter_id) => {
-    return await api
-        .patch(`${apiStudyUrl}chapter_patch/${chapter_id}`)
-}
+const unenrollStudentLight = async (courseId: Id) => {
+  return await api.patch(`${apiStudyUrl}unenroll/light/${courseId}`);
+};
 
-const updateUserPass = async (data) => {
-    return await api
-        .put(apiUserUrl + "reset-password",data
-        )
-}
+const learnGetModuleStages = async (moduleId: Id) => {
+  return await api.get(`${apiStudyUrl}module-stage-list/${moduleId}`);
+};
+
+const updateStage = async (stageId: Id, isCompleted: boolean) => {
+  return await api.post(`${apiStudyUrl}update_stage_progress/${stageId}/?is_completed=${isCompleted}`);
+};
+
+const checkQuizLesson = async (stageId: Id, answers: Payload) => {
+  return await api.post(`${apiStudyUrl}check_quiz_answers/${stageId}`, answers);
+};
+
+const startExam = async (chapterId: Id) => {
+  return await api.post(`${apiStudyUrl}start_exam/${chapterId}`);
+};
+
+const completeExam = async (chapterId: Id) => {
+  return await api.post(`${apiStudyUrl}complete_exam/${chapterId}`);
+};
+
+const chapterStart = async (chapterId: Id) => {
+  return await api.patch(`${apiStudyUrl}chapter_patch/${chapterId}`);
+};
+
+const updateUserPass = async (data: Payload) => {
+  return await api.put(`${apiUserUrl}reset-password`, data);
+};
 
 const StudentService = {
-    studentCourses,
-    updateStage,
-    getLearnLesson,
-    checkEnrollment,
-    enrollToCourse,
-    unenrollStudent,
-    unenrollStudentLight,
-    startExam,
-    completeExam,
-    learnGetModuleStages,
-    checkQuizLesson,
-    learnCoursePageGetChapterList,
-    updateUserPass,
-    chapterStart,
-    // deleteTeacherCourse,
-    // addCourse,
-    // teacherStudents,
+  studentCourses,
+  updateStage,
+  getLearnLesson,
+  checkEnrollment,
+  enrollToCourse,
+  unenrollStudent,
+  unenrollStudentLight,
+  startExam,
+  completeExam,
+  learnGetModuleStages,
+  checkQuizLesson,
+  learnCoursePageGetChapterList,
+  updateUserPass,
+  chapterStart,
 };
 
 export default StudentService;

--- a/src/services/teacher.service.ts
+++ b/src/services/teacher.service.ts
@@ -1,84 +1,74 @@
-import { apiLmsUrl, apiUserUrl,  } from "../shared/config";
+import { apiLmsUrl, apiUserUrl } from "../shared/config";
 import api from "./api";
-// import authHeader from "./auth-header";
+
+type Id = number | string | string[];
+type Payload = unknown;
+
 const teacherDashboard = async () => {
-    return await api
-        .get(apiUserUrl + "teacher/dashboard/"
-        )
-}
+  return await api.get(`${apiUserUrl}teacher/dashboard/`);
+};
+
 const teacherCourses = async () => {
-    return await api
-        .get(apiLmsUrl + "teacher-courses/"
-        )
-}
-const deleteTeacherCourse = async (courseId) => {
-    return await api
-        .delete(`${apiLmsUrl}delete-course/${courseId}/`
-        )
-}
-const archiveTeacherCourse = async (courseId) => {
-    return await api
-        .delete(`${apiLmsUrl}archive-course/${courseId}/`
-        )
-}
-const addCourse = async (...data) => {
-    return await api
-        .post(apiLmsUrl + "course/",
-        ...data,
-            {headers: { "Content-Type": "multipart/form-data" }}
-        )
-}
-const updateCourse = async (course_id, ...data) => {
-    return await api
-        .put(apiLmsUrl + "course/"+course_id,
-        ...data,
-            {headers: { "Content-Type": "multipart/form-data" }}
-        )
-}
-const sentToPublish = async (course_id) => {
-    return await api
-        .put(apiLmsUrl + `courses/${course_id}/send_for_moderation`
-        )
-}
-const teacherStudents = async (teacherId) => {
-    return await api
-        .get(apiLmsUrl + "teacher-students/" + teacherId
-        )
-}
-const getCourseById = async (courseId) => {
-    return await api
-        .get(`${apiLmsUrl}course/?course_id=${courseId}`
-            // {headers: { "Content-Type": "multipart/form-data" }}
-        )
-}
+  return await api.get(`${apiLmsUrl}teacher-courses/`);
+};
+
+const deleteTeacherCourse = async (courseId: Id) => {
+  return await api.delete(`${apiLmsUrl}delete-course/${courseId}/`);
+};
+
+const archiveTeacherCourse = async (courseId: Id) => {
+  return await api.delete(`${apiLmsUrl}archive-course/${courseId}/`);
+};
+
+const addCourse = async (data: Payload) => {
+  return await api.post(`${apiLmsUrl}course/`, data, {
+    headers: { "Content-Type": "multipart/form-data" },
+  });
+};
+
+const updateCourse = async (courseId: Id, data: Payload) => {
+  return await api.put(`${apiLmsUrl}course/${courseId}`, data, {
+    headers: { "Content-Type": "multipart/form-data" },
+  });
+};
+
+const sentToPublish = async (courseId: Id) => {
+  return await api.put(`${apiLmsUrl}courses/${courseId}/send_for_moderation`);
+};
+
+const teacherStudents = async (teacherId: Id) => {
+  return await api.get(`${apiLmsUrl}teacher-students/${teacherId}`);
+};
+
+const getCourseById = async (courseId: Id) => {
+  return await api.get(`${apiLmsUrl}course/?course_id=${courseId}`);
+};
+
 const getTeacherProfile = async () => {
-    return await api
-        .get(apiUserUrl + "teacher-profile"
-        )
-}
-const updateTeacherProfile = async (data) => {
-    return await api
-        .put(apiUserUrl + "teacher-profile-update",data
-        )
-}
-const updateTeacherPass = async (data) => {
-    return await api
-        .put(apiUserUrl + "reset-password",data
-        )
-}
+  return await api.get(`${apiUserUrl}teacher-profile`);
+};
+
+const updateTeacherProfile = async (data: Payload) => {
+  return await api.put(`${apiUserUrl}teacher-profile-update`, data);
+};
+
+const updateTeacherPass = async (data: Payload) => {
+  return await api.put(`${apiUserUrl}reset-password`, data);
+};
+
 const TeacherService = {
-    teacherDashboard,
-    teacherCourses,
-    updateTeacherPass,
-    getTeacherProfile,
-    updateTeacherProfile,
-    deleteTeacherCourse,
-    archiveTeacherCourse,
-    addCourse,
-    updateCourse,
-    sentToPublish,
-    teacherStudents,
-    getCourseById,
+  teacherDashboard,
+  teacherCourses,
+  updateTeacherPass,
+  getTeacherProfile,
+  updateTeacherProfile,
+  deleteTeacherCourse,
+  archiveTeacherCourse,
+  addCourse,
+  updateCourse,
+  sentToPublish,
+  teacherStudents,
+  getCourseById,
 };
 
 export default TeacherService;

--- a/src/services/token.service.ts
+++ b/src/services/token.service.ts
@@ -1,26 +1,36 @@
-const getLocalRefreshToken = () => {
-    const refresh_token = JSON.parse(localStorage.getItem("refresh_token"));
-    return refresh_token;
-  };
-  
-  const getLocalAccessToken = () => {
-    const access_token = JSON.parse(localStorage.getItem("access_token"));
-    return access_token;
-  };
-  
-  const updateLocalRefreshToken = (token) => {
-    localStorage.setItem("refresh_token", JSON.stringify(token));
-  };
+const safeParseToken = (value: string | null): string | null => {
+  if (!value) {
+    return null;
+  }
 
-  const updateLocalAccessToken = (token) => {
-    localStorage.setItem("access_token", JSON.stringify(token));
-  };
-  
-  const TokenService = {
-    getLocalRefreshToken,
-    getLocalAccessToken,
-    updateLocalRefreshToken,
-    updateLocalAccessToken,
-  };
-  
-  export default TokenService;
+  try {
+    return JSON.parse(value) as string;
+  } catch {
+    return null;
+  }
+};
+
+const getLocalRefreshToken = () => {
+  return safeParseToken(localStorage.getItem("refresh_token"));
+};
+
+const getLocalAccessToken = () => {
+  return safeParseToken(localStorage.getItem("access_token"));
+};
+
+const updateLocalRefreshToken = (token: string) => {
+  localStorage.setItem("refresh_token", JSON.stringify(token));
+};
+
+const updateLocalAccessToken = (token: string) => {
+  localStorage.setItem("access_token", JSON.stringify(token));
+};
+
+const TokenService = {
+  getLocalRefreshToken,
+  getLocalAccessToken,
+  updateLocalRefreshToken,
+  updateLocalAccessToken,
+};
+
+export default TokenService;


### PR DESCRIPTION
### Motivation
- Reduce runtime risk and improve editor DX by tightening obvious type gaps in API services and token handling. 
- Make the main site feel modern and responsive by refreshing header/footer and homepage styles and cleaning up small UI quirks. 

### Description
- Introduced consistent `Id`/`Payload`/`SortableItem` types and explicit signatures in the service layer (`src/services/*.ts`) to remove many implicit `any` usages and normalize request builders. 
- Reworked token helpers to use a safe JSON parse and explicit update functions in `src/services/token.service.ts` to avoid crashes on malformed values. 
- Refactored header component (`src/components/basicComponents/Header/*`) to add typed auth/role state (`AuthMode`/`UserRole`), stabilize mobile/menu behavior, and improve modal/drawer handling; updated markup for accessibility. 
- Modernized styles for header, footer and homepage (`src/components/basicComponents/Header/Header.scss`, `src/components/basicComponents/Footer/Footer.scss`, `src/app/app.scss`) including sticky blurred header, responsive footer grid, updated hero and CTA, and removed an unused homepage state. 

### Testing
- Ran lint: `npm run lint` and it completed with no ESLint warnings or errors. ✅
- Ran type-check: `npx tsc --noEmit` (ran during validation) and it still reports unrelated pre-existing TypeScript errors in other files not touched by this PR, so full type-cleanup remains a follow-up. ⚠️
- Launched dev server and captured a homepage screenshot to validate visual changes (artifact: `artifacts/home-modernized.png`) and verified the app responds locally. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a97becd3cc8332928f2413be3cb9f4)