### PR TITLE
Refactor auth forms and fix profile redirect

### DIFF
--- a/src/components/basicComponents/Auth/LoginComponents/Login/Login.scss
+++ b/src/components/basicComponents/Auth/LoginComponents/Login/Login.scss
@@ -1,55 +1,114 @@
 .login-tab__auth-container {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+
+  .auth-container__log-pass-block {
+    width: 100%;
+    max-width: 540px;
     display: flex;
     flex-direction: column;
-    gap: 10px;
-    align-items: center;
-  
-    .auth-container__log-pass-block {
+    gap: 1rem;
+    padding: 1.75rem;
+    border-radius: 28px;
+    background: linear-gradient(180deg, #ffffff 0%, #f7fbff 100%);
+    box-shadow: 0 24px 80px rgba(20, 60, 120, 0.12);
+    border: 1px solid rgba(57, 162, 219, 0.16);
+
+    @media (max-width: 768px) {
+      padding: 1.25rem;
+      border-radius: 24px;
+    }
+  }
+
+  .auth-form__header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    color: #16324f;
+
+    h3 {
+      margin: 0;
+      font-size: 1.75rem;
+      line-height: 1.2;
+    }
+
+    p {
+      margin: 0;
+      color: #5d7288;
+      font-size: 1rem;
+      line-height: 1.5;
+    }
+  }
+
+  .auth-form__badge {
+    display: inline-flex;
+    align-self: flex-start;
+    padding: 0.4rem 0.85rem;
+    border-radius: 999px;
+    background: rgba(57, 162, 219, 0.12);
+    color: #0f6ea8;
+    font-size: 0.85rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+  }
+
+  .form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+  }
+
+  .auth-form__label {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: #23405f;
+  }
+
+  .auth-container__button-confirm {
+    display: flex;
+    justify-content: center;
+    margin-top: 0.5rem;
+
+    .orange-button {
       width: 100%;
-      max-width: 500px;
-      display: flex;
-      flex-direction: column;
-      gap: 10px;
-      justify-content: center;
-  
-      @media (max-width: 768px) {
-        width: 90%;
+      padding: 0.95rem 1.25rem;
+      font-size: 1.05rem;
+      font-weight: 700;
+      color: #ffffff;
+      background: linear-gradient(135deg, #ff8a4c 0%, #ff6b4a 100%);
+      border: none;
+      border-radius: 16px;
+      cursor: pointer;
+      transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+      box-shadow: 0 14px 32px rgba(255, 122, 76, 0.28);
+
+      &:hover:not(:disabled) {
+        transform: translateY(-1px);
+        box-shadow: 0 18px 38px rgba(255, 122, 76, 0.34);
       }
-  
-      .auth-container__button-confirm {
-        display: flex;
-        justify-content: center;
-  
-        .orange-button {
-          padding: 15px 30px;
-          font-size: 1.6rem;
-          color: #ffffff;
-          background-color: #ff7f50;
-          border: none;
-          border-radius: 8px;
-          cursor: pointer;
-          transition: background-color 0.3s ease;
-  
-          &:hover {
-            background-color: #ff6347;
-          }
-  
-          @media (max-width: 768px) {
-            font-size: 1.4rem;
-            padding: 12px 24px;
-          }
-        }
+
+      &:disabled {
+        cursor: wait;
+        opacity: 0.75;
       }
     }
   }
-  
-  .error {
-    color: red;
-    font-size: 0.875rem;
-    margin-top: 0.25rem;
-  }
-  
-  .input-error {
-    border: 1px solid red;
-  }
-  
+}
+
+.error {
+  color: #d64545;
+  font-size: 0.875rem;
+  margin-top: 0.1rem;
+}
+
+.auth-form__server-error {
+  text-align: center;
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  background: rgba(214, 69, 69, 0.08);
+}
+
+.input-error {
+  border: 1px solid #d64545;
+}

--- a/src/components/basicComponents/Auth/LoginComponents/Login/Login.tsx
+++ b/src/components/basicComponents/Auth/LoginComponents/Login/Login.tsx
@@ -1,15 +1,19 @@
+"use client";
 import React, { useState } from "react";
 import * as Yup from "yup";
+import { useRouter } from "next/navigation";
+import { LockOutlined, MailOutlined } from "@ant-design/icons";
 import AuthService from "../../../../../services/auth.service";
 import TextInput from "../../../../reUseComponents/TextInput";
 import "./Login.scss";
-import { LockOutlined, MailOutlined } from "@ant-design/icons";
 
 function AllProfilesLogin() {
+  const router = useRouter();
   const [inputUsernameValue, setInputUsernameValue] = useState("");
   const [inputPasswordValue, setInputPasswordValue] = useState("");
-  const [errors, setErrors] = useState({});
+  const [errors, setErrors] = useState<Record<string, string>>({});
   const [errorMsg, setErrorMsg] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const validationSchema = Yup.object().shape({
     username: Yup.string()
@@ -22,10 +26,12 @@ function AllProfilesLogin() {
 
   const handleInputUsernameChange = (e) => {
     setInputUsernameValue(e.target.value);
+    setErrorMsg("");
   };
 
   const handleInputPasswordChange = (e) => {
     setInputPasswordValue(e.target.value);
+    setErrorMsg("");
   };
 
   const validateForm = async () => {
@@ -49,76 +55,109 @@ function AllProfilesLogin() {
     }
   };
 
+  const persistAuthState = ({ access_token, refresh_token, type }) => {
+    localStorage.setItem("access_token", JSON.stringify(access_token));
+    localStorage.setItem("refresh_token", JSON.stringify(refresh_token));
+    localStorage.setItem("role", JSON.stringify(type));
+    localStorage.setItem(
+      "studentLoginStatus",
+      JSON.stringify(type === "student_model")
+    );
+    window.dispatchEvent(new Event("auth:changed"));
+  };
+
+  const resolveProfileRoute = (role) => {
+    if (role === "teacher_model") {
+      return "/teacher-profile/dashboard";
+    }
+
+    if (role === "student_model") {
+      return "/student-profile/dashboard";
+    }
+
+    return null;
+  };
+
   const submitForm = async (e) => {
     e.preventDefault();
     const isValid = await validateForm();
     if (!isValid) return;
 
-    const formData = new FormData();
-    formData.append("username", inputUsernameValue);
+    const formData = new URLSearchParams();
+    formData.append("username", inputUsernameValue.trim());
     formData.append("password", inputPasswordValue);
 
-    await AuthService.login(formData)
-      .then((response) => {
-        if (response.status === 200 || response.status === 201) {
-          console.log(response.data)
-          localStorage.clear();
-          localStorage.setItem(
-            "access_token",
-            JSON.stringify(response?.data?.access_token)
-          );
-          localStorage.setItem(
-            "refresh_token",
-            JSON.stringify(response?.data?.refresh_token)
-          );
-          if (response?.data?.type === "teacher_model") {
-            localStorage.setItem("role", JSON.stringify(response?.data?.type));
-            window.location.href = "/teacher-profile/dashboard";
-          }
-          if (response?.data?.type === "student_model") {
-            localStorage.setItem("role", JSON.stringify(response?.data?.type));
-            localStorage.setItem("studentLoginStatus", JSON.stringify("true"));
-            window.location.href = "/student-profile/dashboard";
-          }
+    setIsSubmitting(true);
+    setErrorMsg("");
+
+    try {
+      const response = await AuthService.login(formData);
+
+      if (response.status === 200 || response.status === 201) {
+        const nextRoute = resolveProfileRoute(response?.data?.type);
+
+        persistAuthState(response.data);
+
+        if (nextRoute) {
+          router.push(nextRoute);
+          router.refresh();
+          return;
         }
-      })
-      .catch((error) => {
-        setErrorMsg(error.response.data.message);
-      });
+
+        setErrorMsg("Не удалось определить тип профиля для перехода.");
+      }
+    } catch (error) {
+      setErrorMsg(error?.response?.data?.message || "Не удалось выполнить вход.");
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   return (
     <div className="login-tab__auth-container">
       <form onSubmit={submitForm} className="auth-container__log-pass-block">
+        <div className="auth-form__header">
+          <span className="auth-form__badge">Добро пожаловать</span>
+          <h3>Войдите, чтобы продолжить обучение</h3>
+          <p>
+            Используйте email и пароль от вашей учетной записи, чтобы перейти в
+            личный кабинет.
+          </p>
+        </div>
+
         <div className="form-group">
+          <label className="auth-form__label">Email</label>
           <TextInput
             type="email"
             placeholder="Введите email"
             value={inputUsernameValue}
             prefix={<MailOutlined />}
             onChange={handleInputUsernameChange}
-            style={errors.username ? { borderColor: "red" } : {}}
+            style={errors.username ? { borderColor: "#ff6b6b" } : {}}
           />
           {errors.username && <div className="error">{errors.username}</div>}
         </div>
-        <div className="form-group">
-        <TextInput
-        type="password"
-        placeholder="Введите пароль"
-        value={inputPasswordValue}
-        prefix={<LockOutlined />}
-        onChange={handleInputPasswordChange}
-        style={errors.password ? { borderColor: "red" } : {}}
-      />
 
+        <div className="form-group">
+          <label className="auth-form__label">Пароль</label>
+          <TextInput
+            type="password"
+            placeholder="Введите пароль"
+            value={inputPasswordValue}
+            prefix={<LockOutlined />}
+            onChange={handleInputPasswordChange}
+            style={errors.password ? { borderColor: "#ff6b6b" } : {}}
+          />
           {errors.password && <div className="error">{errors.password}</div>}
         </div>
+
         <div className="auth-container__button-confirm">
-          <button className="orange-button" type="submit">
-            Войти
+          <button className="orange-button" type="submit" disabled={isSubmitting}>
+            {isSubmitting ? "Входим..." : "Войти"}
           </button>
         </div>
-        {errorMsg && <div className="error">{errorMsg}</div>}
+
+        {errorMsg && <div className="error auth-form__server-error">{errorMsg}</div>}
       </form>
     </div>
   );

--- a/src/components/basicComponents/Auth/RegisterComponents/Register.scss
+++ b/src/components/basicComponents/Auth/RegisterComponents/Register.scss
@@ -1,65 +1,140 @@
 .login-tab__register-container {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+
+  .register-card {
+    width: 100%;
+    max-width: 540px;
     display: flex;
     flex-direction: column;
-    gap: 10px;
-    align-items: center;
-  
-    .register-container__log-pass-block {
-      width: 100%;
-      max-width: 500px;
-      display: flex;
-      flex-direction: column;
-      gap: 10px;
-      justify-content: center;
-  
-      @media (max-width: 768px) {
-        width: 90%;
-      }
-    }
-  
-    .register-container__button-confirm {
-      display: flex;
-      justify-content: center;
-  
-      .orange-button {
-        padding: 15px 30px;
-        font-size: 1.6rem;
-        color: #ffffff;
-        background-color: #ff7f50;
-        border: none;
-        border-radius: 8px;
-        cursor: pointer;
-        transition: background-color 0.3s ease;
-  
-        &:hover {
-          background-color: #ff6347;
-        }
-  
-        @media (max-width: 768px) {
-          font-size: 1.4rem;
-          padding: 12px 24px;
-        }
-      }
-    }
-  
-    .auth_reg_text {
-      text-align: center;
-      padding: 1rem;
-      font-size: 1.2rem;
-      color: rgb(70, 70, 70);
-      @media (max-width: 768px) {
-        font-size: 1rem;
-      }
+    gap: 1rem;
+    padding: 1.75rem;
+    border-radius: 28px;
+    background: linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
+    box-shadow: 0 24px 80px rgba(20, 60, 120, 0.12);
+    border: 1px solid rgba(57, 162, 219, 0.16);
+
+    @media (max-width: 768px) {
+      padding: 1.25rem;
+      border-radius: 24px;
     }
   }
-  
-  .error {
-    color: red;
-    font-size: 0.875rem;
+
+  .register-card__header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    color: #16324f;
+
+    h3 {
+      margin: 0;
+      font-size: 1.6rem;
+      line-height: 1.25;
+    }
+
+    p {
+      margin: 0;
+      color: #5d7288;
+      font-size: 1rem;
+      line-height: 1.5;
+    }
+  }
+
+  .auth-form__badge {
+    display: inline-flex;
+    align-self: flex-start;
+    padding: 0.4rem 0.85rem;
+    border-radius: 999px;
+    background: rgba(57, 162, 219, 0.12);
+    color: #0f6ea8;
+    font-size: 0.85rem;
+    font-weight: 700;
+  }
+
+  .register-container__log-pass-block {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+  }
+
+  .auth-form__label {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: #23405f;
+  }
+
+  .register-container__button-confirm {
+    display: flex;
+    justify-content: center;
     margin-top: 0.25rem;
+
+    .orange-button {
+      width: 100%;
+      padding: 0.95rem 1.25rem;
+      font-size: 1.05rem;
+      font-weight: 700;
+      color: #ffffff;
+      background: linear-gradient(135deg, #39a2db 0%, #176baf 100%);
+      border: none;
+      border-radius: 16px;
+      cursor: pointer;
+      transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+      box-shadow: 0 14px 32px rgba(23, 107, 175, 0.24);
+
+      &:hover:not(:disabled) {
+        transform: translateY(-1px);
+        box-shadow: 0 18px 38px rgba(23, 107, 175, 0.3);
+      }
+
+      &:disabled {
+        cursor: wait;
+        opacity: 0.75;
+      }
+    }
   }
-  
-  .input-error {
-    border: 1px solid red;
+
+  .auth_reg_text {
+    text-align: center;
+    padding: 1rem;
+    font-size: 0.98rem;
+    line-height: 1.55;
+    color: #52667c;
+    background: rgba(57, 162, 219, 0.08);
+    border-radius: 16px;
   }
-  
+}
+
+.error {
+  color: #d64545;
+  font-size: 0.875rem;
+  margin-top: 0.1rem;
+}
+
+.auth-form__server-error {
+  text-align: center;
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  background: rgba(214, 69, 69, 0.08);
+}
+
+.success-message {
+  text-align: center;
+  padding: 0.85rem 1rem;
+  border-radius: 14px;
+  background: rgba(55, 178, 77, 0.12);
+  color: #237339;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.input-error {
+  border: 1px solid #d64545;
+}

--- a/src/components/basicComponents/Auth/RegisterComponents/Register.tsx
+++ b/src/components/basicComponents/Auth/RegisterComponents/Register.tsx
@@ -1,34 +1,49 @@
+"use client";
 import React, { useState } from "react";
 import * as Yup from "yup";
+import { LockOutlined, MailOutlined } from "@ant-design/icons";
 import AuthService from "../../../../services/auth.service";
 import TextInput from "../../../reUseComponents/TextInput";
 import "./Register.scss";
 
 const RegisterForm = ({ userType }) => {
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [errors, setErrors] = useState({});
-  const [errorMsg, setErrorMsg] = useState('');
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [errorMsg, setErrorMsg] = useState("");
+  const [successMsg, setSuccessMsg] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleEmailChange = (e) => {
     setEmail(e.target.value);
+    setErrorMsg("");
+    setSuccessMsg("");
   };
 
   const handlePasswordChange = (e) => {
     setPassword(e.target.value);
+    setErrorMsg("");
+    setSuccessMsg("");
   };
 
   const validationSchema = Yup.object().shape({
-    email: Yup.string().email("Некорректный email, пожалуйста добавьте корректный").required("Обязательно"),
-    password: Yup.string().min(8, "Пароль должен содержать минимум 8 символов").required("Обязательно"),
+    email: Yup.string()
+      .email("Некорректный email, пожалуйста добавьте корректный")
+      .required("Обязательно"),
+    password: Yup.string()
+      .min(8, "Пароль должен содержать минимум 8 символов")
+      .required("Обязательно"),
   });
 
   const validateForm = async () => {
     try {
-      await validationSchema.validate({
-        email,
-        password,
-      }, { abortEarly: false });
+      await validationSchema.validate(
+        {
+          email,
+          password,
+        },
+        { abortEarly: false }
+      );
       setErrors({});
       return true;
     } catch (err) {
@@ -41,81 +56,116 @@ const RegisterForm = ({ userType }) => {
     }
   };
 
+  const successText =
+    userType === "student"
+      ? "Регистрация ученика прошла успешно. Теперь вы можете войти в систему."
+      : "Регистрация преподавателя прошла успешно. Теперь вы можете войти в систему.";
+
   const handleSubmit = async (e) => {
     e.preventDefault();
     const isValid = await validateForm();
     if (!isValid) return;
 
     const formData = new FormData();
-    formData.append("email", email);
+    formData.append("email", email.trim());
     formData.append("password", password);
 
-    if (userType === "student") {
-      formData.append("interested_categories", "");
-      await AuthService.studentRegister(formData).then((response) => {
-        if (response.status === 200 || response.status === 201) {
-          setEmail("");
-          setPassword("");
-          console.log(response);
-        }
-      }).catch((error) => {
-        setErrorMsg(error.response.data.message);
-      });
-    } else if (userType === "teacher") {
-      formData.append("qualification", "");
-      formData.append("name", "");
-      formData.append("lastName", "");
-      formData.append("skills", "");
-      await AuthService.teacherRegister(formData).then((response) => {
-        if (response.status === 200 || response.status === 201) {
-          setEmail("");
-          setPassword("");
-          console.log(response);
-        }
-      }).catch((error) => {
-        setErrorMsg(error.response.data.message);
-      });
+    setIsSubmitting(true);
+    setErrorMsg("");
+    setSuccessMsg("");
+
+    try {
+      if (userType === "student") {
+        formData.append("interested_categories", "");
+        await AuthService.studentRegister(formData);
+      } else if (userType === "teacher") {
+        formData.append("qualification", "");
+        formData.append("name", "");
+        formData.append("lastName", "");
+        formData.append("skills", "");
+        await AuthService.teacherRegister(formData);
+      }
+
+      setEmail("");
+      setPassword("");
+      setSuccessMsg(successText);
+    } catch (error) {
+      setErrorMsg(error?.response?.data?.message || "Не удалось завершить регистрацию.");
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
   return (
     <div className="login-tab__register-container">
-      <div className="register-container__log-pass-block">
-        <TextInput
-          type={"email"}
-          placeholder={"Введите ваш email"}
-          value={email}
-          onChange={handleEmailChange}
-          style={errors.email ? { borderColor: 'red' } : {}}
-        />
-        {errors.email && <div className="error">{errors.email}</div>}
-        <TextInput
-          type={"password"}
-          placeholder={"Введите пароль"}
-          value={password}
-          onChange={handlePasswordChange}
-          style={errors.password ? { borderColor: 'red' } : {}}
-        />
-        {errors.password && <div className="error">{errors.password}</div>}
-      </div>
-      <div className="register-container__button-confirm">
-        <button className="orange-button" onClick={handleSubmit}>Регистрация</button>
-      </div>
-      <div md={4} className="auth_reg_text">
-        {userType === "student" ? (
-          <span>
-            Выберите этот вариант если вы хотите проходить курсы на нашей
-            платформе, в последующем вы сможете расширить свою учетную запись
-            для преподавания.
+      <form className="register-card" onSubmit={handleSubmit}>
+        <div className="register-card__header">
+          <span className="auth-form__badge">
+            {userType === "student" ? "Новый ученик" : "Новый преподаватель"}
           </span>
-        ) : (
-          <span>
-            Выберите этот вариант если вы хотите создавать курсы на нашей
-            платформе. В будущем вы сможете на них зарабатывать.
-          </span>
-        )}
-      </div>
-      {errorMsg && <div className="error">{errorMsg}</div>}
+          <h3>
+            {userType === "student"
+              ? "Создайте аккаунт для обучения"
+              : "Создайте аккаунт для публикации курсов"}
+          </h3>
+          <p>
+            {userType === "student"
+              ? "После регистрации вы сможете записываться на курсы и отслеживать прогресс."
+              : "После регистрации вы сможете оформлять профиль преподавателя и запускать свои курсы."}
+          </p>
+        </div>
+
+        <div className="register-container__log-pass-block">
+          <div className="form-group">
+            <label className="auth-form__label">Email</label>
+            <TextInput
+              type="email"
+              placeholder="Введите ваш email"
+              value={email}
+              prefix={<MailOutlined />}
+              onChange={handleEmailChange}
+              style={errors.email ? { borderColor: "#ff6b6b" } : {}}
+            />
+            {errors.email && <div className="error">{errors.email}</div>}
+          </div>
+
+          <div className="form-group">
+            <label className="auth-form__label">Пароль</label>
+            <TextInput
+              type="password"
+              placeholder="Введите пароль"
+              value={password}
+              prefix={<LockOutlined />}
+              onChange={handlePasswordChange}
+              style={errors.password ? { borderColor: "#ff6b6b" } : {}}
+            />
+            {errors.password && <div className="error">{errors.password}</div>}
+          </div>
+        </div>
+
+        <div className="register-container__button-confirm">
+          <button className="orange-button" type="submit" disabled={isSubmitting}>
+            {isSubmitting ? "Создаем аккаунт..." : "Зарегистрироваться"}
+          </button>
+        </div>
+
+        <div className="auth_reg_text">
+          {userType === "student" ? (
+            <span>
+              Этот режим подойдет, если вы хотите проходить курсы на платформе и
+              развивать свои навыки в удобном темпе.
+            </span>
+          ) : (
+            <span>
+              Этот режим подойдет, если вы хотите создавать курсы, делиться
+              опытом и развивать собственную экспертную витрину.
+            </span>
+          )}
+        </div>
+
+        {successMsg && <div className="success-message">{successMsg}</div>}
+        {errorMsg && <div className="error auth-form__server-error">{errorMsg}</div>}
+      </form>
     </div>
   );
 };

--- a/src/components/basicComponents/Auth/TabsLoginRegister/TabComponent/Tabs.scss
+++ b/src/components/basicComponents/Auth/TabsLoginRegister/TabComponent/Tabs.scss
@@ -1,95 +1,78 @@
 .modal__tabs {
   display: flex;
   flex-direction: column;
-  // justify-content: end;
-  // align-items: flex-end;
 
   .tabs {
     position: relative;
     width: 100%;
-    max-width: 500px;
-    min-height: 600px; // Ensure the container has a fixed minimum height
+    max-width: 640px;
+    min-height: 600px;
     margin: auto;
-    margin-top: 0.5rem;
-    margin-bottom: 1.5rem;
-    padding: 2rem 1rem;
-    color: #e8f0f2;
-
-    border-radius: 2rem;
+    padding: 1rem 0 0.5rem;
+    color: #16324f;
 
     @media (max-width: 768px) {
-      padding: 1.5rem 1rem;
-      min-height: 500px; // Adjust for smaller screens if necessary
-    }
-
-    .close-icon {
-      position: absolute;
-      top: 1rem;
-      right: 1rem;
-      font-size: 24px;
-      cursor: pointer;
-      color: #e8f0f2;
-
-      @media (max-width: 768px) {
-        font-size: 20px;
-      }
+      min-height: auto;
+      padding-top: 0.25rem;
     }
   }
 
   ul.tabsNav {
     width: 100%;
-    max-width: 400px;
-    margin: 0 auto 2rem;
+    max-width: 420px;
+    margin: 0 auto 1.5rem;
     display: flex;
     align-items: center;
     justify-content: space-between;
-    border: 1px solid #39a2db;
-    border-radius: 2rem;
-    padding-left: 0px;
+    gap: 0.25rem;
+    background: #eef6fb;
+    border: 1px solid rgba(57, 162, 219, 0.18);
+    border-radius: 20px;
+    padding: 0.35rem;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
 
     @media (max-width: 768px) {
-      width: 90%;
+      width: 100%;
+      max-width: none;
     }
   }
 
   ul.tabsNav li {
     width: 50%;
-    padding: 0.5em;
+    padding: 0.85rem 1rem;
     list-style: none;
     text-align: center;
     cursor: pointer;
-    font-size: 1.6rem;
-    transition: all 0.7s;
-    border-bottom-left-radius: 2rem;
-    border-top-left-radius: 2rem;
-    color: #fa803a;
-    @media (max-width: 768px) {
-      font-size: 1.2rem;
-    }
-  }
-
-  ul.tabsNav li:nth-child(2) {
-    border-radius: 0;
-    border-bottom-right-radius: 2rem;
-    border-top-right-radius: 2rem;
+    font-size: 1rem;
+    font-weight: 700;
+    transition: all 0.25s ease;
+    border-radius: 16px;
+    color: #5d7288;
   }
 
   ul.tabsNav li:hover {
-    background: rgba(0, 5, 4, 0.15);
+    color: #16324f;
+    background: rgba(255, 255, 255, 0.75);
   }
 
   ul.tabsNav li.active {
-    background: #39a2db;
+    color: #ffffff;
+    background: linear-gradient(135deg, #39a2db 0%, #176baf 100%);
+    box-shadow: 0 14px 28px rgba(23, 107, 175, 0.22);
   }
 
-  .LoginTab p,a
-  .RegisterTab p {
-    font-size: 1.6rem;
-    text-align: center;
-    color: #fa803a;
+  .LoginTab,
+  .RegisterTab {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
 
-    @media (max-width: 768px) {
-      font-size: 1.4rem;
+    > p {
+      margin: 0;
+      font-size: 1rem;
+      line-height: 1.5;
+      text-align: center;
+      color: #5d7288;
     }
   }
 
@@ -98,29 +81,31 @@
   }
 
   .react-tabs__tab-list {
-    width: 40%;
-    margin: 0 auto 2rem;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding-left: 0px;
-    color: #ff7f50;
-    @media (max-width: 768px) {
-      width: 90%;
-    }
+    width: 100%;
+    margin: 0 auto 1.25rem;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.5rem;
+    padding-left: 0;
   }
 
   .react-tabs__tab {
-    width: 50%;
-    padding: 0.5rem;
+    padding: 0.85rem 1rem;
     list-style: none;
     text-align: center;
     cursor: pointer;
-    transition: all 0.7s;
+    transition: all 0.25s ease;
+    border-radius: 14px;
+    border: 1px solid rgba(57, 162, 219, 0.18);
+    background: #f7fbff;
+    color: #4e647a;
+    font-weight: 600;
   }
 
   .react-tabs__tab--selected {
-    background: #39a2db;
+    background: rgba(57, 162, 219, 0.12);
+    border-color: rgba(57, 162, 219, 0.34);
+    color: #176baf;
   }
 
   .react-tabs__tab--disabled {
@@ -129,17 +114,7 @@
   }
 
   .react-tabs__tab:hover {
-    background: rgba(50, 224, 196, 0.15);
-  }
-
-  .react-tabs__tab:first-child {
-    border-bottom-left-radius: 2rem;
-    border-top-left-radius: 2rem;
-  }
-
-  .react-tabs__tab:last-child {
-    border-bottom-right-radius: 2rem;
-    border-top-right-radius: 2rem;
+    background: rgba(57, 162, 219, 0.08);
   }
 
   .react-tabs__tab-panel {
@@ -148,10 +123,5 @@
 
   .react-tabs__tab-panel--selected {
     display: block;
-    font-size: 1.6rem;
-
-    @media (max-width: 768px) {
-      font-size: 1.4rem;
-    }
   }
 }

--- a/src/components/basicComponents/Header/Header.tsx
+++ b/src/components/basicComponents/Header/Header.tsx
@@ -34,24 +34,43 @@ function Header() {
 
     const handleResize = () => setIsMobile(window.innerWidth <= 768);
 
-    const token = localStorage.getItem("access_token");
-    const storedRole = localStorage.getItem("role");
+    const syncAuthState = () => {
+      const token = localStorage.getItem("access_token");
+      const storedRole = localStorage.getItem("role");
 
-    setIsAuth(Boolean(token));
-    if (storedRole) {
-      setRole(JSON.parse(storedRole) as UserRole);
-    }
+      setIsAuth(Boolean(token));
 
+      if (!storedRole) {
+        setRole(null);
+        return;
+      }
+
+      try {
+        setRole(JSON.parse(storedRole) as UserRole);
+      } catch {
+        setRole(storedRole as UserRole);
+      }
+    };
+
+    syncAuthState();
     handleResize();
-    window.addEventListener("resize", handleResize);
 
-    return () => window.removeEventListener("resize", handleResize);
+    window.addEventListener("resize", handleResize);
+    window.addEventListener("storage", syncAuthState);
+    window.addEventListener("auth:changed", syncAuthState);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      window.removeEventListener("storage", syncAuthState);
+      window.removeEventListener("auth:changed", syncAuthState);
+    };
   }, []);
 
   const toggleMenu = () => setMenuOpen((prev) => !prev);
 
   const handleLogout = () => {
     localStorage.clear();
+    window.dispatchEvent(new Event("auth:changed"));
     setIsAuth(false);
     setRole(null);
     router.push("/");

--- a/src/context/AuthProvider.tsx
+++ b/src/context/AuthProvider.tsx
@@ -20,17 +20,65 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const [role, setRole] = useState<Role>(null);
 
   useEffect(() => {
-    const storedRole = localStorage.getItem("role");
-    if (storedRole === "teacher_model" || storedRole === "student_model") {
-      setRole(storedRole);
-      setAuthenticated(true);
-    }
+    const syncAuth = () => {
+      const storedRole = localStorage.getItem("role");
+
+      if (!storedRole) {
+        setRole(null);
+        setAuthenticated(false);
+        return;
+      }
+
+      try {
+        const parsedRole = JSON.parse(storedRole) as Role;
+
+        if (parsedRole === "teacher_model" || parsedRole === "student_model") {
+          setRole(parsedRole);
+          setAuthenticated(true);
+          return;
+        }
+      } catch {
+        if (storedRole === "teacher_model" || storedRole === "student_model") {
+          setRole(storedRole);
+          setAuthenticated(true);
+          return;
+        }
+      }
+
+      setRole(null);
+      setAuthenticated(false);
+    };
+
+    syncAuth();
+    window.addEventListener("storage", syncAuth);
+    window.addEventListener("auth:changed", syncAuth);
+
+    return () => {
+      window.removeEventListener("storage", syncAuth);
+      window.removeEventListener("auth:changed", syncAuth);
+    };
   }, []);
 
   const toggleAuthentication = () => {
     const currentRole = localStorage.getItem("role");
-    if (currentRole === "teacher_model" || currentRole === "student_model") {
-      setAuthenticated((prev) => !prev);
+
+    if (!currentRole) {
+      setAuthenticated(false);
+      setRole(null);
+      return;
+    }
+
+    try {
+      const parsedRole = JSON.parse(currentRole) as Role;
+      if (parsedRole === "teacher_model" || parsedRole === "student_model") {
+        setRole(parsedRole);
+        setAuthenticated((prev) => !prev);
+      }
+    } catch {
+      if (currentRole === "teacher_model" || currentRole === "student_model") {
+        setRole(currentRole);
+        setAuthenticated((prev) => !prev);
+      }
     }
   };
 


### PR DESCRIPTION
### Motivation
- Улучшить внешний вид и UX окна аутентификации/регистрации и устранить баг, из‑за которого после успешного входа не обновлялся интерфейс и не происходил переход в личный кабинет.

### Description
- Переработаны компоненты `Login` и `Register`: обновлён JSX и SCSS, добавлены заголовки, подсказки, состояния загрузки/disabled и отображение server‑ошибок (файлы в `src/components/basicComponents/Auth/...`).
- Логин теперь отправляется через `URLSearchParams`, данные аутентификации сохраняются единообразно через `persistAuthState` и после успешного входа выполняется `router.push` на профиль (файл `Login.tsx`).
- Синхронизация состояния авторизации добавлена в `Header` и `AuthProvider`: слушаются события `storage` и кастомное `auth:changed`, при logout генерируется событие для немедленного обновления UI (файлы `Header.tsx` и `AuthProvider.tsx`).
- Обновлены стили вкладок авторизации (`Tabs.scss`) и переоформлены `Login.scss`/`Register.scss` для согласованного визуального ритма и лучшей адаптивности.

### Testing
- Запущена сборка проекта через `npm run build`, сборка прошла успешно. 
- Запуск `npm run lint` завершается ошибкой в текущей среде из‑за поведения `next lint` (в этой CI/контейнерной среде команда интерпретируется некорректно), поэтому линтер не прошёл здесь автоматически.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69beaf3d76108332a8c51f687fab391f)