### PR TITLE
feat: add shared design system and unify reusable component styles

### DIFF
--- a/src/components/basicComponents/Auth/LoginComponents/Login/Login.scss
+++ b/src/components/basicComponents/Auth/LoginComponents/Login/Login.scss
@@ -4,28 +4,19 @@
   width: 100%;
 
   .auth-container__log-pass-block {
+    @extend .ui-auth-card;
     width: 100%;
     max-width: 540px;
     display: flex;
     flex-direction: column;
     gap: 1rem;
-    padding: 1.75rem;
-    border-radius: 28px;
-    background: linear-gradient(180deg, #ffffff 0%, #f7fbff 100%);
-    box-shadow: 0 24px 80px rgba(20, 60, 120, 0.12);
-    border: 1px solid rgba(57, 162, 219, 0.16);
-
-    @media (max-width: 768px) {
-      padding: 1.25rem;
-      border-radius: 24px;
-    }
   }
 
   .auth-form__header {
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-    color: #16324f;
+    color: var(--color-text);
 
     h3 {
       margin: 0;
@@ -35,34 +26,22 @@
 
     p {
       margin: 0;
-      color: #5d7288;
+      color: var(--color-text-soft);
       font-size: 1rem;
       line-height: 1.5;
     }
   }
 
   .auth-form__badge {
-    display: inline-flex;
-    align-self: flex-start;
-    padding: 0.4rem 0.85rem;
-    border-radius: 999px;
-    background: rgba(57, 162, 219, 0.12);
-    color: #0f6ea8;
-    font-size: 0.85rem;
-    font-weight: 700;
-    letter-spacing: 0.02em;
+    @extend .ui-badge;
   }
 
   .form-group {
-    display: flex;
-    flex-direction: column;
-    gap: 0.45rem;
+    @extend .ui-form-group;
   }
 
   .auth-form__label {
-    font-size: 0.95rem;
-    font-weight: 600;
-    color: #23405f;
+    @extend .ui-form-label;
   }
 
   .auth-container__button-confirm {
@@ -76,11 +55,11 @@
       font-size: 1.05rem;
       font-weight: 700;
       color: #ffffff;
-      background: linear-gradient(135deg, #ff8a4c 0%, #ff6b4a 100%);
+      background: linear-gradient(135deg, var(--color-accent) 0%, var(--color-accent-strong) 100%);
       border: none;
-      border-radius: 16px;
+      border-radius: var(--radius-md);
       cursor: pointer;
-      transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+      transition: transform var(--transition-base), box-shadow var(--transition-base), opacity var(--transition-base);
       box-shadow: 0 14px 32px rgba(255, 122, 76, 0.28);
 
       &:hover:not(:disabled) {
@@ -97,18 +76,12 @@
 }
 
 .error {
-  color: #d64545;
+  color: var(--color-danger);
   font-size: 0.875rem;
   margin-top: 0.1rem;
 }
 
 .auth-form__server-error {
   text-align: center;
-  padding: 0.75rem 1rem;
-  border-radius: 14px;
-  background: rgba(214, 69, 69, 0.08);
-}
-
-.input-error {
-  border: 1px solid #d64545;
+  @extend .ui-error;
 }

--- a/src/components/basicComponents/Auth/RegisterComponents/Register.scss
+++ b/src/components/basicComponents/Auth/RegisterComponents/Register.scss
@@ -4,28 +4,19 @@
   width: 100%;
 
   .register-card {
+    @extend .ui-auth-card;
     width: 100%;
     max-width: 540px;
     display: flex;
     flex-direction: column;
     gap: 1rem;
-    padding: 1.75rem;
-    border-radius: 28px;
-    background: linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
-    box-shadow: 0 24px 80px rgba(20, 60, 120, 0.12);
-    border: 1px solid rgba(57, 162, 219, 0.16);
-
-    @media (max-width: 768px) {
-      padding: 1.25rem;
-      border-radius: 24px;
-    }
   }
 
   .register-card__header {
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-    color: #16324f;
+    color: var(--color-text);
 
     h3 {
       margin: 0;
@@ -35,40 +26,27 @@
 
     p {
       margin: 0;
-      color: #5d7288;
+      color: var(--color-text-soft);
       font-size: 1rem;
       line-height: 1.5;
     }
   }
 
   .auth-form__badge {
-    display: inline-flex;
-    align-self: flex-start;
-    padding: 0.4rem 0.85rem;
-    border-radius: 999px;
-    background: rgba(57, 162, 219, 0.12);
-    color: #0f6ea8;
-    font-size: 0.85rem;
-    font-weight: 700;
+    @extend .ui-badge;
   }
 
   .register-container__log-pass-block {
+    @extend .ui-form-stack;
     width: 100%;
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
   }
 
   .form-group {
-    display: flex;
-    flex-direction: column;
-    gap: 0.45rem;
+    @extend .ui-form-group;
   }
 
   .auth-form__label {
-    font-size: 0.95rem;
-    font-weight: 600;
-    color: #23405f;
+    @extend .ui-form-label;
   }
 
   .register-container__button-confirm {
@@ -82,11 +60,11 @@
       font-size: 1.05rem;
       font-weight: 700;
       color: #ffffff;
-      background: linear-gradient(135deg, #39a2db 0%, #176baf 100%);
+      background: linear-gradient(135deg, var(--color-primary-soft) 0%, var(--color-primary) 100%);
       border: none;
-      border-radius: 16px;
+      border-radius: var(--radius-md);
       cursor: pointer;
-      transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+      transition: transform var(--transition-base), box-shadow var(--transition-base), opacity var(--transition-base);
       box-shadow: 0 14px 32px rgba(23, 107, 175, 0.24);
 
       &:hover:not(:disabled) {
@@ -103,38 +81,23 @@
 
   .auth_reg_text {
     text-align: center;
-    padding: 1rem;
-    font-size: 0.98rem;
     line-height: 1.55;
-    color: #52667c;
-    background: rgba(57, 162, 219, 0.08);
-    border-radius: 16px;
+    @extend .ui-info;
   }
 }
 
 .error {
-  color: #d64545;
+  color: var(--color-danger);
   font-size: 0.875rem;
   margin-top: 0.1rem;
 }
 
 .auth-form__server-error {
   text-align: center;
-  padding: 0.75rem 1rem;
-  border-radius: 14px;
-  background: rgba(214, 69, 69, 0.08);
+  @extend .ui-error;
 }
 
 .success-message {
   text-align: center;
-  padding: 0.85rem 1rem;
-  border-radius: 14px;
-  background: rgba(55, 178, 77, 0.12);
-  color: #237339;
-  font-size: 0.95rem;
-  font-weight: 600;
-}
-
-.input-error {
-  border: 1px solid #d64545;
+  @extend .ui-success;
 }

--- a/src/components/reUseComponents/CustomCardNew.scss
+++ b/src/components/reUseComponents/CustomCardNew.scss
@@ -1,21 +1,26 @@
 .custom-course-card {
-  display: flex;
-  flex-direction: row;
-  border: 1px solid #ddd;
-  border-radius: 8px;
-  width: 400px;
-  height: 120px;
+  display: grid;
+  grid-template-columns: 128px 1fr;
+  width: min(100%, 420px);
+  min-height: 132px;
   overflow: hidden;
   cursor: pointer;
-  transition: box-shadow 0.3s ease;
+  border: 1px solid rgba(57, 162, 219, 0.14);
+  border-radius: 22px;
+  background: linear-gradient(180deg, var(--color-surface) 0%, #f9fbff 100%);
+  box-shadow: var(--shadow-sm);
+  transition: transform var(--transition-base), box-shadow var(--transition-base), border-color var(--transition-base);
 
   &:hover {
-    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-md);
+    border-color: rgba(57, 162, 219, 0.28);
   }
 
   &__image {
-    width: 120px;
-    height: 120px;
+    width: 100%;
+    height: 100%;
+    min-height: 132px;
     overflow: hidden;
 
     img {
@@ -26,73 +31,35 @@
   }
 
   .custom-course-card__body {
-    width: 280px;
-    height: 120px;
     display: flex;
     flex-direction: column;
-    padding: 10px;
+    justify-content: center;
+    gap: 0.45rem;
+    padding: 1rem 1.1rem;
 
     .body__title {
-      font-size: 0.7em;
-      margin-bottom: 0.5em;
-      font-weight: bold;
+      font-size: 1rem;
+      line-height: 1.35;
+      font-weight: 700;
+      color: var(--color-text);
     }
 
     .body__description {
-      font-size: 0.9em;
-      color: #555;
-      font-weight: bold;
+      font-size: 0.92rem;
+      line-height: 1.5;
+      color: var(--color-text-soft);
+      display: -webkit-box;
+      -webkit-line-clamp: 3;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
     }
   }
 
-  // Стили для планшетов
-  @media (max-width: 768px) {
-    width: 350px;
-    height: 100px;
+  @media (max-width: 640px) {
+    grid-template-columns: 1fr;
 
     &__image {
-      width: 100px;
-      height: 100px;
-    }
-
-    .custom-course-card__body {
-      width: 250px;
-      height: 100px;
-      padding: 8px;
-
-      .body__title {
-        font-size: 0.8em;
-      }
-
-      .body__description {
-        font-size: 0.85em;
-      }
-    }
-  }
-
-  // Стили для мобильных устройств
-  @media (max-width: 480px) {
-    flex-direction: row;
-    width: 100%;
-    height: auto;
-
-    &__image {
-      width: 50%;
-      height: 120px; // Увеличим высоту изображения, чтобы оно лучше смотрелось на мобильных
-    }
-
-    .custom-course-card__body {
-      width: 100%;
-      height: auto;
-      padding: 12px;
-
-      .body__title {
-        font-size: 0.7em;
-      }
-
-      .body__description {
-        font-size: 0.7em;
-      }
+      min-height: 190px;
     }
   }
 }

--- a/src/components/reUseComponents/LmsButton.scss
+++ b/src/components/reUseComponents/LmsButton.scss
@@ -1,95 +1,94 @@
-// _LmsButton.scss
-
-// Основные стили
 .lms-button {
-    padding: 0.5rem 1rem;
-    border-radius: 0.375rem;
-    font-weight: bold;
-    cursor: pointer;
-    transition: background-color 0.2s, border-color 0.2s;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
+  --button-bg: linear-gradient(135deg, var(--color-primary-soft) 0%, var(--color-primary) 100%);
+  --button-color: #fff;
+  --button-border: transparent;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  min-width: fit-content;
+  border: 1px solid var(--button-border);
+  border-radius: var(--radius-md);
+  background: var(--button-bg);
+  color: var(--button-color);
+  font-weight: 700;
+  line-height: 1;
+  cursor: pointer;
+  box-shadow: 0 14px 32px rgba(23, 107, 175, 0.18);
+  transition: transform var(--transition-base), box-shadow var(--transition-base), opacity var(--transition-base), background var(--transition-base), color var(--transition-base), border-color var(--transition-base);
 
-    // Цветовые схемы (варианты)
+  &:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 18px 38px rgba(20, 60, 120, 0.22);
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.7;
+    box-shadow: none;
+  }
+
+  &.primary {
+    --button-bg: linear-gradient(135deg, var(--color-primary-soft) 0%, var(--color-primary) 100%);
+  }
+
+  &.secondary {
+    --button-bg: linear-gradient(135deg, #7b8da3 0%, #536579 100%);
+  }
+
+  &.success {
+    --button-bg: linear-gradient(135deg, #49c66b 0%, var(--color-success) 100%);
+  }
+
+  &.danger {
+    --button-bg: linear-gradient(135deg, var(--color-accent) 0%, var(--color-accent-strong) 100%);
+  }
+
+  &.outline {
+    --button-bg: transparent;
+    --button-border: currentColor;
+    box-shadow: none;
+
     &.primary {
-      background-color: #6fcaff;
-      color: white;
-      &:hover {
-        background-color: #0056b3;
-      }
+      color: var(--color-primary);
     }
-  
+
     &.secondary {
-      background-color: #6c757d;
-      color: white;
-      &:hover {
-        background-color: #5a6268;
-      }
+      color: #536579;
     }
-  
+
     &.success {
-      background-color: #28a745;
-      color: white;
-      &:hover {
-        background-color: #218838;
-      }
+      color: var(--color-success);
     }
-  
+
     &.danger {
-      background-color: #dc3545;
-      color: white;
-      &:hover {
-        background-color: #c82333;
-      }
+      color: var(--color-accent-strong);
     }
-  
-    // Стили (default, inline, outline)
-    &.default {
-      border: none;
+
+    &:hover:not(:disabled) {
+      background: rgba(57, 162, 219, 0.08);
     }
-  
-    &.outline {
-      background-color: transparent;
-      border: 2px solid;
-      &.primary {
-        color: #007bff;
-        border-color: #007bff;
-        &:hover {
-          background-color: #007bff;
-          color: white;
-        }
-      }
-      &.secondary {
-        color: #6c757d;
-        border-color: #6c757d;
-        &:hover {
-          background-color: #6c757d;
-          color: white;
-        }
-      }
-    }
-  
-    &.inline {
-      display: inline-block;
-    }
-  
-    // Размеры (small, medium, large)
-    &.small {
-      padding: 0.25rem 0.5rem;
-      font-size: 0.875rem;
-      height: 2rem; // Установка высоты для маленького размера
-    }
-  
-    &.medium {
-      padding: 0.5rem 1rem;
-      font-size: 1rem;
-      height: 2.5rem; // Установка высоты для среднего размера
-    }
-  
-    &.large {
-      padding: 0.75rem 1.5rem;
-      font-size: 1.25rem;
-      height: 3rem; // Установка высоты для большого размера
-    }
+  }
+
+  &.inline {
+    box-shadow: none;
+  }
+
+  &.small {
+    min-height: 2.25rem;
+    padding: 0.55rem 0.9rem;
+    font-size: 0.875rem;
+  }
+
+  &.medium {
+    min-height: 2.75rem;
+    padding: 0.8rem 1.2rem;
+    font-size: 0.95rem;
+  }
+
+  &.large {
+    min-height: 3.15rem;
+    padding: 0.95rem 1.5rem;
+    font-size: 1.05rem;
+  }
 }

--- a/src/components/reUseComponents/LmsButton.tsx
+++ b/src/components/reUseComponents/LmsButton.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import "./LmsButton.scss"; // Импортируем стили
+import "./LmsButton.scss";
 
 interface LmsButtonProps {
   buttonText: string;
@@ -7,20 +7,27 @@ interface LmsButtonProps {
   variant?: "primary" | "secondary" | "success" | "danger";
   size?: "small" | "medium" | "large";
   styleType?: "default" | "inline" | "outline";
+  type?: "button" | "submit" | "reset";
+  disabled?: boolean;
+  className?: string;
 }
 
 export default function LmsButton({
   buttonText,
   handleClick,
-  variant = "primary", // Цветовые схемы: primary, secondary, success, danger
-  size = "medium",     // Размеры: small, medium, large
-  styleType = "default", // Стили: default, inline, outline
+  variant = "primary",
+  size = "medium",
+  styleType = "default",
+  type = "button",
+  disabled = false,
+  className = "",
 }: LmsButtonProps) {
-  // Объединяем классы для кнопки
-  const buttonClass = `lms-button ${variant} ${size} ${styleType}`;
+  const buttonClass = ["lms-button", variant, size, styleType, className]
+    .filter(Boolean)
+    .join(" ");
 
   return (
-    <button onClick={handleClick} className={buttonClass}>
+    <button type={type} onClick={handleClick} className={buttonClass} disabled={disabled}>
       {buttonText}
     </button>
   );

--- a/src/components/reUseComponents/Select.scss
+++ b/src/components/reUseComponents/Select.scss
@@ -6,28 +6,32 @@
   width: 100%;
 
   .ant-select-selector {
-    font-size: 14px;
-    min-height: 40px !important;
-    border-radius: 6px !important;
-    border: 1px solid #d9d9d9 !important;
+    min-height: 48px !important;
+    border-radius: var(--radius-md) !important;
+    border: 1px solid #d5dfeb !important;
+    padding: 0.35rem 0.75rem !important;
+    box-shadow: none !important;
     display: flex;
     align-items: center;
+    transition: border-color var(--transition-base), box-shadow var(--transition-base) !important;
   }
 
-  &:hover .ant-select-selector {
-    border-color: #1890ff !important;
+  &:hover .ant-select-selector,
+  &.ant-select-focused .ant-select-selector {
+    border-color: var(--color-primary-soft) !important;
   }
 
   &.ant-select-focused .ant-select-selector {
-    border-color: #1890ff !important;
-    box-shadow: 0 0 0 2px rgba(24, 144, 255, 0.2) !important;
+    box-shadow: var(--shadow-focus) !important;
   }
 
-  .ant-select-selection-placeholder {
-    color: #999;
+  .ant-select-selection-placeholder,
+  .ant-select-selection-item {
+    color: var(--color-text-soft);
+    font-size: 0.95rem;
   }
 
   .ant-select-arrow {
-    color: #1890ff;
+    color: var(--color-primary);
   }
 }

--- a/src/components/reUseComponents/TextInput.scss
+++ b/src/components/reUseComponents/TextInput.scss
@@ -1,54 +1,43 @@
 .custom-text-input {
-    position: relative;
-    display: flex;
+  @extend .ui-input-shell;
+  flex-wrap: wrap;
+  min-height: 3rem;
+  padding: 0.3rem 0.65rem;
+
+  .prefix-icon,
+  .suffix-icon {
+    display: inline-flex;
     align-items: center;
-    padding: 8px;
-    border: 1px solid #d9d9d9;
-    border-radius: 4px;
-    background-color: #fff;
-  
-    &:focus-within {
-      border-color: #40a9ff;
-      box-shadow: 0 0 5px rgba(24, 144, 255, 0.2);
-    }
-  
-    .prefix-icon,
-    .suffix-icon {
-      margin: 0 8px;
-      font-size: 16px;
-      color: #8c8c8c;
-    }
-   textarea {
+    justify-content: center;
+    color: #7a8ea4;
+    font-size: 1rem;
+  }
+
+  input,
+  textarea {
     flex: 1;
+    width: 100%;
     border: none;
     outline: none;
-    padding: 8px;
-    font-size: 14px;
-    resize: vertical;
-    min-height: 60px;
+    background: transparent;
+    padding: 0.55rem 0;
+    font-size: 0.95rem;
+    color: var(--color-text);
     font-family: inherit;
 
     &::placeholder {
-      color: #bfbfbf;
+      color: #9aaabd;
     }
   }
-    input {
-      flex: 1;
-      border: none;
-      outline: none;
-      padding: 8px;
-      font-size: 14px;
-      color: #000;
-      
-      &::placeholder {
-        color: #bfbfbf;
-      }
-    }
-  
-    .input-error {
-      color: #ff4d4f;
-      font-size: 12px;
-      margin-top: 4px;
-    }
+
+  textarea {
+    resize: vertical;
+    min-height: 120px;
   }
-  
+
+  .input-error {
+    width: 100%;
+    color: var(--color-danger);
+    font-size: 0.8rem;
+  }
+}

--- a/src/components/reUseComponents/TextInput.tsx
+++ b/src/components/reUseComponents/TextInput.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import "./TextInput.scss";
 
 interface TextInputProps {
-  type?: "text" | "textarea";
+  type?: string;
   placeholder?: string;
   value?: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
@@ -10,6 +10,8 @@ interface TextInputProps {
   error?: string;
   prefix?: React.ReactNode;
   suffix?: React.ReactNode;
+  className?: string;
+  isTextArea?: boolean;
 }
 
 const TextInput: React.FC<TextInputProps> = ({
@@ -21,45 +23,24 @@ const TextInput: React.FC<TextInputProps> = ({
   error,
   prefix,
   suffix,
+  className = "",
+  isTextArea = false,
 }) => {
-  const defaultStyle = {
-    padding: "8px 12px",
-    width: "100%",
-    display: "flex",
-    alignItems: "center",
-    border: "1px solid #d9d9d9",
-    borderRadius: "4px",
-    boxSizing: "border-box",
-  };
-
-  const inputStyle = {
-    flex: 1,
-    border: "none",
-    outline: "none",
-    padding: "8px",
-  };
-
-  const combinedStyle = { ...defaultStyle, ...style };
+  const isArea = isTextArea || type === "textarea";
 
   return (
-    <div className="custom-text-input" style={combinedStyle}>
+    <div
+      className={["custom-text-input", error ? "ui-input-shell--error" : "", className]
+        .filter(Boolean)
+        .join(" ")}
+      style={style}
+    >
       {prefix && <div className="prefix-icon">{prefix}</div>}
 
-      {type === "textarea" ? (
-        <textarea
-          value={value}
-          placeholder={placeholder}
-          onChange={onChange}
-          style={inputStyle}
-        />
+      {isArea ? (
+        <textarea value={value} placeholder={placeholder} onChange={onChange} />
       ) : (
-        <input
-          type={type}
-          value={value}
-          placeholder={placeholder}
-          onChange={onChange}
-          style={inputStyle}
-        />
+        <input type={type} value={value} placeholder={placeholder} onChange={onChange} />
       )}
 
       {suffix && <div className="suffix-icon">{suffix}</div>}

--- a/src/styles/design-system.scss
+++ b/src/styles/design-system.scss
@@ -1,0 +1,145 @@
+:root {
+  --font-sans: 'Roboto', 'Open Sans', sans-serif;
+  --color-bg: #f4f7fb;
+  --color-surface: #ffffff;
+  --color-surface-muted: #f8fbff;
+  --color-text: #16324f;
+  --color-text-soft: #5d7288;
+  --color-border: rgba(57, 162, 219, 0.18);
+  --color-border-strong: rgba(57, 162, 219, 0.32);
+  --color-primary: #176baf;
+  --color-primary-strong: #0f6ea8;
+  --color-primary-soft: #39a2db;
+  --color-accent: #ff8a4c;
+  --color-accent-strong: #ff6b4a;
+  --color-success: #237339;
+  --color-success-soft: rgba(55, 178, 77, 0.12);
+  --color-danger: #d64545;
+  --color-danger-soft: rgba(214, 69, 69, 0.08);
+  --shadow-sm: 0 10px 24px rgba(20, 60, 120, 0.08);
+  --shadow-md: 0 20px 60px rgba(20, 60, 120, 0.12);
+  --shadow-focus: 0 0 0 4px rgba(57, 162, 219, 0.16);
+  --radius-sm: 12px;
+  --radius-md: 16px;
+  --radius-lg: 24px;
+  --radius-pill: 999px;
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-7: 1.75rem;
+  --space-8: 2rem;
+  --transition-base: 0.2s ease;
+}
+
+body {
+  background: linear-gradient(180deg, #f9fbff 0%, #f4f7fb 100%);
+  color: var(--color-text);
+}
+
+.ui-card,
+.ui-auth-card {
+  background: linear-gradient(180deg, var(--color-surface) 0%, var(--color-surface-muted) 100%);
+  border: 1px solid var(--color-border);
+  border-radius: 28px;
+  box-shadow: var(--shadow-md);
+}
+
+.ui-auth-card {
+  padding: var(--space-7);
+}
+
+.ui-form-stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.ui-form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.ui-form-label {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #23405f;
+}
+
+.ui-badge {
+  display: inline-flex;
+  align-self: flex-start;
+  padding: 0.4rem 0.85rem;
+  border-radius: var(--radius-pill);
+  background: rgba(57, 162, 219, 0.12);
+  color: var(--color-primary-strong);
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.ui-info,
+.ui-error,
+.ui-success {
+  padding: 0.85rem 1rem;
+  border-radius: 14px;
+  font-size: 0.95rem;
+}
+
+.ui-info {
+  background: rgba(57, 162, 219, 0.08);
+  color: #52667c;
+}
+
+.ui-error {
+  background: var(--color-danger-soft);
+  color: var(--color-danger);
+}
+
+.ui-success {
+  background: var(--color-success-soft);
+  color: var(--color-success);
+  font-weight: 600;
+}
+
+.ui-input-shell {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.2rem 0.4rem;
+  border: 1px solid #d5dfeb;
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  transition: border-color var(--transition-base), box-shadow var(--transition-base), transform var(--transition-base);
+}
+
+.ui-input-shell:hover {
+  border-color: var(--color-border-strong);
+}
+
+.ui-input-shell:focus-within {
+  border-color: var(--color-primary-soft);
+  box-shadow: var(--shadow-focus);
+}
+
+.ui-input-shell--error {
+  border-color: rgba(214, 69, 69, 0.65);
+}
+
+.ui-section-title {
+  font-size: clamp(1.5rem, 2.5vw, 2rem);
+  line-height: 1.2;
+  color: var(--color-text);
+}
+
+@media (max-width: 768px) {
+  .ui-auth-card {
+    padding: var(--space-5);
+    border-radius: var(--radius-lg);
+  }
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,3 +1,4 @@
+@import "./design-system.scss";
 /* index.css или App.css */
 @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&display=swap');


### PR DESCRIPTION
### Motivation

- Provide a single base of design tokens and small UI primitives so components share colors, spacing, radii and shadows. 
- Replace ad-hoc per-component styling with a common foundation to make visual updates and theming easier across the app. 
- Migrate a set of frequently used reusable components (buttons, inputs, selects, cards) and auth surfaces to consume the shared tokens and primitives.

### Description

- Added a shared stylesheet `src/styles/design-system.scss` exposing CSS variables (colors, radii, spacing, shadows) and small utility primitives such as `.ui-auth-card`, `.ui-input-shell`, `.ui-badge`, `.ui-form-*`, then imported it from `src/styles/globals.css`.
- Refactored the reusable button by updating `src/components/reUseComponents/LmsButton.tsx` to support `type`, `disabled` and `className` props and moved visual variants to `src/components/reUseComponents/LmsButton.scss` using the new tokens. 
- Refactored the text input to remove inline styles and add `isTextArea` support in `src/components/reUseComponents/TextInput.tsx` and updated `src/components/reUseComponents/TextInput.scss` to use `.ui-input-shell` and tokenized colors/spacing. 
- Restyled `Select` (`src/components/reUseComponents/Select.scss`), `CustomCourseCard` (`src/components/reUseComponents/CustomCardNew.scss`) and aligned auth form styles (`src/components/basicComponents/Auth/.../Login.scss` and `Register.scss`) to consume the shared tokens and primitives.

### Testing

- Ran `npx tsc --noEmit` which did not pass in this environment because the repository contains many pre-existing TypeScript errors outside the scope of these style-focused changes. 
- Attempted `timeout 120s npm run build` (Next.js production build) but the build did not complete within the environment timeout and reported Next.js warnings (`images.domains` deprecation) and a lock contention, so a full production build could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfab5817e88332a73476706f8c08c2)